### PR TITLE
Restore by url

### DIFF
--- a/local/restore_by_url/README.md
+++ b/local/restore_by_url/README.md
@@ -1,0 +1,3 @@
+# Restore by Url
+
+This local plugin provides a way to restore a Moodle course using a remote URL to the mbz file.

--- a/local/restore_by_url/downloads/.gitignore
+++ b/local/restore_by_url/downloads/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/local/restore_by_url/lang/en/local_restore_by_url.php
+++ b/local/restore_by_url/lang/en/local_restore_by_url.php
@@ -23,3 +23,4 @@ $string['form_remote_url_field_desc'] = 'The remote URL to the .mbz file.';
 $string['form_remote_url_submit'] = 'Restore';
 $string['form_error_no_url_provided'] = 'You are missing the URL!';
 $string['form_error_url_missing'] = 'The file at that location is missing!';
+$string['form_error_unable_to_download'] = 'Sorry, we were unable to download the file.';

--- a/local/restore_by_url/lang/en/local_restore_by_url.php
+++ b/local/restore_by_url/lang/en/local_restore_by_url.php
@@ -1,0 +1,20 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * Localization file
+ */
+$string['manage'] = 'Restore by Url';
+$string['pluginname'] = 'Restore by Url';

--- a/local/restore_by_url/lang/en/local_restore_by_url.php
+++ b/local/restore_by_url/lang/en/local_restore_by_url.php
@@ -24,3 +24,4 @@ $string['form_remote_url_submit'] = 'Restore';
 $string['form_error_no_url_provided'] = 'You are missing the URL!';
 $string['form_error_url_missing'] = 'The file at that location is missing!';
 $string['form_error_unable_to_download'] = 'Sorry, we were unable to download the file.';
+$string['form_remote_url_restoring'] = 'Restoring...';

--- a/local/restore_by_url/restore.php
+++ b/local/restore_by_url/restore.php
@@ -32,7 +32,21 @@ if (!empty($_POST)) {
     if (!remote_file_exists($remoteFile)) {
         $error = get_string('form_error_url_missing', 'local_restore_by_url');
     }
+    set_time_limit(0);
     download_remote_archive($remoteFile, $destination);
+
+    if (file_exists($destination)) {
+        $scriptPath = $CFG->dirroot . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'cli' . DIRECTORY_SEPARATOR . 'restore_backup.php';
+        exec('php ' . $scriptPath . ' --categoryid=1 --file=' . $destination);
+        header('Location: ' . new moodle_url('/local/restore_by_url/restore.php?success=true'));
+        exit();
+    } else {
+        $error = get_string('form_error_unable_to_download', 'local_restore_by_url');
+    }
+}
+$success = '';
+if ((!empty($_GET)) && ($_GET['success'] === 'true')) {
+    $success = 'You course has been restored!';
 }
 
 echo $OUTPUT->header();
@@ -43,6 +57,9 @@ echo $OUTPUT->header();
         <?php
             if ($error !== '') {
                 echo '<p style="font-style: italic; color: red;">' . $error . '</p>';
+            }
+            if ($success !== '') {
+                echo '<p style="font-style: italic; color: blue;">' . $success . '</p>';
             }
         ?>
         <fieldset>

--- a/local/restore_by_url/restore.php
+++ b/local/restore_by_url/restore.php
@@ -32,16 +32,19 @@ if (!empty($_POST)) {
     if (!remote_file_exists($remoteFile)) {
         $error = get_string('form_error_url_missing', 'local_restore_by_url');
     }
-    set_time_limit(0);
-    download_remote_archive($remoteFile, $destination);
 
-    if (file_exists($destination)) {
-        $scriptPath = $CFG->dirroot . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'cli' . DIRECTORY_SEPARATOR . 'restore_backup.php';
-        exec('php ' . $scriptPath . ' --categoryid=1 --file=' . $destination);
-        header('Location: ' . new moodle_url('/local/restore_by_url/restore.php?success=true'));
-        exit();
-    } else {
-        $error = get_string('form_error_unable_to_download', 'local_restore_by_url');
+    if ($error === '') {
+        set_time_limit(0);
+        download_remote_archive($remoteFile, $destination);
+
+        if (file_exists($destination)) {
+            $scriptPath = $CFG->dirroot . DIRECTORY_SEPARATOR . 'admin' . DIRECTORY_SEPARATOR . 'cli' . DIRECTORY_SEPARATOR . 'restore_backup.php';
+            exec('php ' . $scriptPath . ' --categoryid=1 --file=' . $destination);
+            header('Location: ' . new moodle_url('/local/restore_by_url/restore.php?success=true'));
+            exit();
+        } else {
+            $error = get_string('form_error_unable_to_download', 'local_restore_by_url');
+        }
     }
 }
 $success = '';
@@ -54,14 +57,16 @@ echo $OUTPUT->header();
 <form id="resture-by-url-form" action="<?php echo new moodle_url('/local/restore_by_url/restore.php'); ?>" method="post">
     <div class="settingsform">
         <h2><?php echo get_string('pluginname', 'local_restore_by_url'); ?></h2>
-        <?php
-            if ($error !== '') {
-                echo '<p style="font-style: italic; color: red;">' . $error . '</p>';
-            }
-            if ($success !== '') {
-                echo '<p style="font-style: italic; color: blue;">' . $success . '</p>';
-            }
-        ?>
+        <div id="message-holder">
+            <?php
+                if ($error !== '') {
+                    echo '<p style="font-style: italic; color: red;">' . $error . '</p>';
+                }
+                if ($success !== '') {
+                    echo '<p style="font-style: italic; color: blue;">' . $success . '</p>';
+                }
+            ?>
+        </div>
         <fieldset>
             <div class="clearer"></div>
             <div id="admin-form_remote_url_field" class="form-item row">
@@ -80,7 +85,9 @@ echo $OUTPUT->header();
         </fieldset>
         <div class="row">
             <div class="offset-sm-3 col-sm-3">
-                <button type="submit" class="btn btn-primary"><?php echo get_string('form_remote_url_submit', 'local_restore_by_url'); ?></button>
+                <button type="submit" class="btn btn-primary" onClick="this.disabled=true; this.innerText='<?php echo get_string('form_remote_url_restoring', 'local_restore_by_url'); ?>';">
+                    <?php echo get_string('form_remote_url_submit', 'local_restore_by_url'); ?>
+                </button>
             </div>
         </div>
     </div>

--- a/local/restore_by_url/restore.php
+++ b/local/restore_by_url/restore.php
@@ -22,6 +22,8 @@ require_once(dirname(__FILE__) .DIRECTORY_SEPARATOR . 'utilities.php');
 
 admin_externalpage_setup('local_restore_by_url_settings');
 $error = '';
+$destination = dirname(__FILE__) .DIRECTORY_SEPARATOR . 'downloads' . DIRECTORY_SEPARATOR . 'archive.mbz';
+
 if (!empty($_POST)) {
     if ((!array_key_exists('form_remote_url_field', $_POST)) || ($_POST['form_remote_url_field'] === '')) {
         $error = get_string('form_error_no_url_provided', 'local_restore_by_url');
@@ -30,6 +32,7 @@ if (!empty($_POST)) {
     if (!remote_file_exists($remoteFile)) {
         $error = get_string('form_error_url_missing', 'local_restore_by_url');
     }
+    download_remote_archive($remoteFile, $destination);
 }
 
 echo $OUTPUT->header();

--- a/local/restore_by_url/restore.php
+++ b/local/restore_by_url/restore.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * A custom form to retrieve the URL for the backup file
+ */
+require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once(dirname(__FILE__) .DIRECTORY_SEPARATOR . 'utilities.php');
+
+admin_externalpage_setup('local_restore_by_url_settings');
+$error = '';
+if (!empty($_POST)) {
+    if ((!array_key_exists('form_remote_url_field', $_POST)) || ($_POST['form_remote_url_field'] === '')) {
+        $error = get_string('form_error_no_url_provided', 'local_restore_by_url');
+    }
+    $remoteFile = $_POST['form_remote_url_field'];
+    if (!remote_file_exists($remoteFile)) {
+        $error = get_string('form_error_url_missing', 'local_restore_by_url');
+    }
+}
+
+echo $OUTPUT->header();
+?>
+<form id="resture-by-url-form" action="<?php echo new moodle_url('/local/restore_by_url/restore.php'); ?>" method="post">
+    <div class="settingsform">
+        <h2><?php echo get_string('pluginname', 'local_restore_by_url'); ?></h2>
+        <?php
+            if ($error !== '') {
+                echo '<p style="font-style: italic; color: red;">' . $error . '</p>';
+            }
+        ?>
+        <fieldset>
+            <div class="clearer"></div>
+            <div id="admin-form_remote_url_field" class="form-item row">
+                <div class="form-label col-sm-3 text-sm-right">
+                    <label for="id_s_local_chat_attachments_messaging_support_email"><?php echo get_string('form_remote_url_field', 'local_restore_by_url'); ?></label>
+                    <span class="form-shortname d-block small text-muted">local_chat_attachments | form_remote_url_field</span>
+                </div>
+                <div class="form-setting col-sm-9">
+                    <div class="form-text defaultsnext">
+                        <input type="text" name="form_remote_url_field" value="" size="30" id="id_form_remote_url_field" class="form-control text-ltr">
+                    </div>
+                    <div class="form-defaultinfo text-muted text-ltr">Default: Empty</div>
+                    <div class="form-description mt-3"><p><?php echo get_string('form_remote_url_field_desc', 'local_restore_by_url'); ?></p></div>
+                </div>
+            </div>
+        </fieldset>
+        <div class="row">
+            <div class="offset-sm-3 col-sm-3">
+                <button type="submit" class="btn btn-primary"><?php echo get_string('form_remote_url_submit', 'local_restore_by_url'); ?></button>
+            </div>
+        </div>
+    </div>
+</form>
+<?php
+echo $OUTPUT->footer();

--- a/local/restore_by_url/settings.php
+++ b/local/restore_by_url/settings.php
@@ -14,12 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Localization file
+ * Settings for this plugin.
  */
-$string['manage'] = 'Restore by URL';
-$string['pluginname'] = 'Restore by URL';
-$string['form_remote_url_field'] = 'URL';
-$string['form_remote_url_field_desc'] = 'The remote URL to the .mbz file.';
-$string['form_remote_url_submit'] = 'Restore';
-$string['form_error_no_url_provided'] = 'You are missing the URL!';
-$string['form_error_url_missing'] = 'The file at that location is missing!';
+defined('MOODLE_INTERNAL') || die();
+
+if ($hassiteconfig) {
+    /**
+     * Add a link to the course settings
+     */
+    $ADMIN->add(
+        'courses',
+        new admin_externalpage(
+            'local_restore_by_url_settings',
+            new lang_string('pluginname', 'local_restore_by_url'),
+            new moodle_url('/local/restore_by_url/restore.php')
+        )
+    );
+}

--- a/local/restore_by_url/utilities.php
+++ b/local/restore_by_url/utilities.php
@@ -1,5 +1,5 @@
 <?php
-// This file is part of Moodle - https://moodle.org/
+// This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -14,12 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Localization file
+ * Various PHP utility functions.
  */
-$string['manage'] = 'Restore by URL';
-$string['pluginname'] = 'Restore by URL';
-$string['form_remote_url_field'] = 'URL';
-$string['form_remote_url_field_desc'] = 'The remote URL to the .mbz file.';
-$string['form_remote_url_submit'] = 'Restore';
-$string['form_error_no_url_provided'] = 'You are missing the URL!';
-$string['form_error_url_missing'] = 'The file at that location is missing!';
+/**
+ * Check whether the given URL exists.
+ *
+ * @param  string $url The URL
+ * @return boolean     yes|no
+ */
+function remote_file_exists($url) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_NOBODY, true);
+    curl_exec($ch);
+    $retcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    return ($retcode === 200);
+}

--- a/local/restore_by_url/utilities.php
+++ b/local/restore_by_url/utilities.php
@@ -30,3 +30,13 @@ function remote_file_exists($url) {
     curl_close($ch);
     return ($retcode === 200);
 }
+/**
+ * Download the remote archive locally.
+ *
+ * @param  string $src  The source file
+ * @param  string $dest The destination file
+ * @return void
+ */
+function download_remote_archive($src, $dest) {
+    file_put_contents($dest, file_get_contents($src));
+}

--- a/local/restore_by_url/version.php
+++ b/local/restore_by_url/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * Our versioning file
+ */
+/**
+ * Required version of Moodle 2.0
+ *
+ */
+$plugin->requires = 2010112400;
+/**
+ * Our version number
+ *
+ */
+$plugin->version = 10000;
+$plugin->component = 'local_restore_by_url';
+$plugin->cron = 0;
+$plugin->release = '1.0.0 (Build: 10000)';
+$plugin->maturity = MATURITY_STABLE;

--- a/local/restore_by_url/version.php
+++ b/local/restore_by_url/version.php
@@ -25,8 +25,8 @@ $plugin->requires = 2010112400;
  * Our version number
  *
  */
-$plugin->version = 10000;
+$plugin->version = 10010;
 $plugin->component = 'local_restore_by_url';
 $plugin->cron = 0;
-$plugin->release = '1.0.0 (Build: 10000)';
+$plugin->release = '1.0.10 (Build: 10010)';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Created a local plugin that enables the admin to restore a course using a URL.  The plugin use the CLI tool of moodle to import the course.  This plugin requires the `exec()` PHP function.
