### PR TITLE
Adding ability to enroll cohorts into courses

### DIFF
--- a/local/ws_enrolcohort/.github/workflows/moodle-ci.yaml
+++ b/local/ws_enrolcohort/.github/workflows/moodle-ci.yaml
@@ -1,0 +1,80 @@
+name: moodle-plugin-ci
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.2'
+            moodle-branch: 'MOODLE_39_STABLE'
+            extensions: mbstring
+          - php: '7.2'
+            moodle-branch: 'MOODLE_310_STABLE'
+            extensions: mbstring
+          - php: '7.3'
+            moodle-branch: 'MOODLE_311_STABLE'
+            extensions: [sodium, mbstring]
+          - php: '7.3'
+            moodle-branch: 'MOODLE_400_STABLE'
+            extensions: [sodium, mbstring, exif]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: pgsql
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: Run phplint
+        run: moodle-plugin-ci phplint
+
+      - name: Run phpcpd
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: Run phpmd
+        run: moodle-plugin-ci phpmd
+
+      - name: Run validate
+        run: moodle-plugin-ci validate
+
+      - name: Run savepoints
+        run: moodle-plugin-ci savepoints
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --coverage-text

--- a/local/ws_enrolcohort/.github/workflows/moodle-release.yaml
+++ b/local/ws_enrolcohort/.github/workflows/moodle-release.yaml
@@ -1,0 +1,110 @@
+#
+# Whenever version.php is changed, add to Moodle Plugins directory at https://moodle.org/plugins.
+# Thanks https://github.com/danmarsden :)
+#
+
+name: Releasing in the Plugins directory
+
+on:
+  push:
+    paths:
+      - 'version.php'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '7.3'
+            moodle-branch: 'MOODLE_400_STABLE'
+            extensions: [sodium, mbstring, exif]
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: max_input_vars=5000
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: pgsql
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: Run phplint
+        run: moodle-plugin-ci phplint
+
+      - name: Run phpcpd
+        run: moodle-plugin-ci phpcpd || true
+
+      - name: Run phpmd
+        run: moodle-plugin-ci phpmd
+
+      - name: Run validate
+        run: moodle-plugin-ci validate
+
+      - name: Run savepoints
+        run: moodle-plugin-ci savepoints
+
+      - name: PHPUnit tests
+        if: ${{ always() }}
+        run: moodle-plugin-ci phpunit --coverage-text
+
+      - name: Release at Moodle.org by calling the service function
+        id: add-version
+        env:
+          PLUGIN: local_ws_enrolcohort
+          BRANCH: master
+          CURL: curl -s
+          ENDPOINT: https://moodle.org/webservice/rest/server.php
+          TOKEN: ${{ secrets.MOODLE_ORG_TOKEN }}
+          FUNCTION: local_plugins_add_version
+
+        run: |
+          ZIPURL="https://github.com/emyb/moodle-local_ws_enrolcohort/archive/refs/heads/${BRANCH}.zip"
+          RESPONSE=$(${CURL} ${ENDPOINT} --data-urlencode "wstoken=${TOKEN}" \
+                                         --data-urlencode "wsfunction=${FUNCTION}" \
+                                         --data-urlencode "moodlewsrestformat=json" \
+                                         --data-urlencode "frankenstyle=${PLUGIN}" \
+                                         --data-urlencode "zipurl=${ZIPURL}" \
+                                         --data-urlencode "vcssystem=git" \
+                                         --data-urlencode "vcsrepositoryurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+                                         --data-urlencode "vcstag=${TAGNAME}" \
+                                         --data-urlencode "changelogurl=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/${BRANCH}/CHANGELOG.md" \
+                                         --data-urlencode "altdownloadurl=${ZIPURL}")
+          echo "::set-output name=response::${RESPONSE}"
+      - name: Evaluate the response
+        id: evaluate-response
+        env:
+          RESPONSE: ${{ steps.add-version.outputs.response }}
+        run: |
+          jq <<< ${RESPONSE}
+          jq --exit-status ".id" <<< ${RESPONSE} > /dev/null

--- a/local/ws_enrolcohort/.gitignore
+++ b/local/ws_enrolcohort/.gitignore
@@ -1,0 +1,39 @@
+# This file specifies intentionally untracked files that all Moodle git
+# repositories should ignore. It is recommended not to modify this file in your
+# local clone. Instead, use .git/info/exclude and add new records there as
+# needed.
+#
+# Example: if you deploy a contributed plugin mod/foobar into your site, put
+# the following line into .git/info/exclude file in your Moodle clone:
+# /mod/foobar/
+#
+# See gitignore(5) man page for more details
+#
+exampleresponses.json
+/config.php
+/lib/editor/tinymce/extra/tools/temp/
+*~
+*.swp
+/tags
+/TAGS
+/cscope.*
+/.patches/
+/.idea/
+/nbproject/
+CVS
+.DS_Store
+/.settings/
+/.project
+/.buildpath
+/.cache
+phpunit.xml
+# Composer support. Do not ignore composer.json, or composer.lock. These should be shipped by us.
+composer.phar
+/vendor/
+/behat.yml
+*/yui/build/*/*-coverage.js
+/lib/yuilib/*/build/*/*-coverage.js
+# lib/yuilib/version/module/module-coverage.js
+/lib/yuilib/*/*/*-coverage.js
+atlassian-ide-plugin.xml
+/node_modules/

--- a/local/ws_enrolcohort/CHANGELOG.md
+++ b/local/ws_enrolcohort/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Moodle Webservices for Cohort Enrolment CHANGELOG.
+This change log is not following the format based on Keep a Changelog... yet. 
+
+Version history:
+
+## [v3.3.4] - 2022062800
+
+* Finally added github actions for testing against multiple moodle versions and environments
+* Added a thing for uploading to Moodle Plugins database when the version file is changed. Be careful!!! Thanks [@danmarsden](https://github.com/danmarsden)
+* Moved the things around in the change log so that the latest change is at the top :)
+* Hmmm...
+
+## [v3.3.3] - 2019042900
+for Moodle 3.3, 3.4, 3.5, and 3.6. Released Monday, 29 April 2019
+
+* Fixed issue that was preventing a cohort enrolment instance being added to a course.
+  * This was happening for sites that had more than 25 cohorts available at a context. This limit is a default value when calling cohort_get_available_cohorts().
+  * Thanks to Thomas (thoschi) for this fix.
+* Updated unit tests to create 100 cohorts before calling the webservice add_instance() function.
+* Tagged this release.
+
+## [v3.3.2] - 20180600
+In the very beginning!!!
+
+* Added additional check in php unit test delete instance to ensure that the cohort enrolment instance was removed.
+* Implemented privacy API.

--- a/local/ws_enrolcohort/README.md
+++ b/local/ws_enrolcohort/README.md
@@ -1,0 +1,140 @@
+# Moodle Webservices for Cohort Enrolment.
+
+* [What is this plugin and why was it developed?](#what-is-this-plugin-and-why-was-it-developed?)
+* [What can this plugin do?](#what-can-this-plugin-do?)
+* [What else can this plugin do?](#what-else-can-this-plugin-do?)
+* [What can this plugin not do?](#what-can-this-plugin-not-do?)
+* [How do I install this plugin?](#how-do-i-install-this-plugin?)
+* [What version of Moodle can I install this on?](#what-version-of-moodle-can-i-install-this-on?)
+* [How do I use this plugin?](#how-do-i-use-this-plugin?)
+* [Examples JSON responses](#example-json-responses)
+
+What is this plugin and why was it developed?
+---------------------------------------------
+
+This is a local plugin with webservice functions.
+
+It was developed for <a href="https://www.twoa.ac.nz" target="_blank" alt="Link to Te Wānanga O Aotearoa website" title="Link to Te Wānanga O Aotearoa website">Te Wānanga O Aotearoa</a>
+to streamline the enrolment of tauira (student, learner) into courses. Cohorts and courses are created using Moodle webservices but 
+adding cohort enrolment instances to courses was a manual process. 
+
+The overall goal is to have this webservice function integrated into Moodle core.
+
+
+What can this plugin do?
+-------------------------
+
+This local plugin enables people to add a cohort enrolment instance to a course using webservices.
+
+What else can this plugin do?
+------------------------------
+
+In addition to adding a cohort enrolment instance to a course using webservices, this plugin can also:
+
+* Delete an existing cohort enrolment instance
+* Update an existing cohort enrolment instance
+    * The name of the cohort enrolment instance
+    * The status of the cohort enrolment instance (i.e. active or inactive) 
+    * The role that the users of the cohort enrolment instance is synchronised with
+    * The group that users of the cohort enrolment instance are added to 
+      (i.e. create a new group, an existing group that belongs to the course, none)
+* Get a list of all cohort enrolment instances
+* Get a list of cohort enrolment instances for a specific course
+
+What can this plugin not do?
+----------------------------
+
+This plugin can not do anything that is not listed under [What can this plugin do?](#what-can-this-plugin-do?)
+or [What else can this plugin do?](#what-else-can-this-plugin-do?)
+
+How do I install this plugin?
+-----------------------------
+
+This plugin can be installed by following the official 
+<a href="http://docs.moodle.org/en/Installing_plugins" target="_blank">Moodle documentation</a>. 
+
+
+What version of Moodle can I install this on?
+---------------------------------------------
+
+This plugin has only been developed and tested for Moodle 3.3.
+
+How do I use this plugin?
+-------------------------
+
+This plugin can be used in accordance with the official 
+<a href="https://docs.moodle.org/en/Using_web_services" target="_blank">Moodle documentation</a>.
+
+Example JSON responses.
+-----------------------
+
+This is an example of a JSON response to the webservice function get_instances().
+
+`{
+     "id": -1,
+     "code": 200,
+     "message": "Found 0 cohort enrolment instances in 2 courses (All courses).",
+     "data": []
+ }`
+ 
+Here are some example JSON responses to the webservice function add_instance().
+ 
+ `{
+      "exception": "local_ws_enrolcohort\\exceptions\\cohort_not_found_exception",
+      "errorcode": "objectnotfound",
+      "message": "Object does not exist!",
+      "debuginfo": "Could not find cohort with id 2"
+  }`
+  
+ `{
+      "id": 24,
+      "code": 201,
+      "message": "Cohort enrolment instance added.",
+      "data": [
+          {
+              "object": "course",
+              "id": 2,
+              "name": "TestCourse1",
+              "idnumber": "",
+              "shortname": "TestCourse1",
+              "visible": 1,
+              "format": "topics"
+          },
+          {
+              "object": "cohort",
+              "id": 4,
+              "name": "Test",
+              "idnumber": "1",
+              "visible": 1
+          },
+          {
+              "object": "role",
+              "id": 1,
+              "shortname": "manager"
+          },
+          {
+              "object": "data",
+              "name": "",
+              "cohortid": 4,
+              "roleid": 1,
+              "groupid": 0,
+              "status": 0
+          },
+          {
+              "object": "group",
+              "id": 0,
+              "name": "Enrol instance group none.",
+              "courseid": -1
+          },
+          {
+              "object": "enrol",
+              "id": 24,
+              "name": "Cohort sync (Test - Manager) - Using system generated name.",
+              "courseid": 2,
+              "cohortid": 4,
+              "roleid": 1,
+              "groupid": 0,
+              "status": 0
+          }
+      ]
+  }`

--- a/local/ws_enrolcohort/classes/exceptions/cohort_enrol_instance_already_synced_with_role_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/cohort_enrol_instance_already_synced_with_role_exception.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A cohort enrolment instance that is already synchronised with role exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use \local_ws_enrolcohort\tools;
+
+class cohort_enrol_instance_already_synced_with_role_exception extends \moodle_exception {
+    public function __construct($enrolinstanceid, $roleid) {
+        // Prepare some strings and things.
+        $errorcode  = 'enrolcohortalreadysyncedwithrole';
+        $a          = ['enrolid' => $enrolinstanceid, 'roleid' => $roleid];
+        $debuginfo  = tools::get_string('enrolcohortalreadysyncedwithrole:message', $a);
+
+        parent::__construct($errorcode, tools::COMPONENT_NAME, '', null, $debuginfo);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/cohort_enrol_instance_not_found_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/cohort_enrol_instance_not_found_exception.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cohort enrolment instance does not exist exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class cohort_enrol_instance_not_found_exception extends object_not_found_exception {
+    public function __construct($enrolinstanceid = null) {
+        parent::__construct('cohort enrol instance', 'id', $enrolinstanceid);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/cohort_enrol_method_not_available_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/cohort_enrol_method_not_available_exception.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cohort enrolment method not available exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use local_ws_enrolcohort\tools;
+
+class cohort_enrol_method_not_available_exception extends \moodle_exception {
+    public function __construct() {
+        parent::__construct('cohortenrolmethodnotavailable', tools::COMPONENT_NAME);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/cohort_not_available_at_context_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/cohort_not_available_at_context_exception.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cohort not available at context exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class cohort_not_available_at_context_exception extends not_available_at_context_exception {
+    public function __construct($id = '') {
+        parent::__construct('Cohort', $id, 'available');
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/cohort_not_found_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/cohort_not_found_exception.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cohort not found exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class cohort_not_found_exception extends object_not_found_exception {
+    public function __construct($cohortid = null) {
+        parent::__construct('cohort', 'id', $cohortid);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/course_is_site_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/course_is_site_exception.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Course is the site id exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use local_ws_enrolcohort\tools;
+
+class course_is_site_exception extends invalid_course_exception {
+    public function __construct() {
+        parent::__construct(tools::get_string('invalidcourse:issite'));
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/course_not_found_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/course_not_found_exception.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Course not found exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class course_not_found_exception extends object_not_found_exception {
+    public function __construct($courseid = null) {
+        parent::__construct('course', 'id', $courseid);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/group_not_found_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/group_not_found_exception.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Group not found exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class group_not_found_exception extends object_not_found_exception {
+    public function __construct($groupid = null) {
+        parent::__construct('group', 'id', $groupid);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/invalid_course_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/invalid_course_exception.php
@@ -1,0 +1,37 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Course is invalid exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use local_ws_enrolcohort\tools;
+
+class invalid_course_exception extends \moodle_exception {
+    public function __construct($debuginfo = null) {
+        parent::__construct('invalidcourse', tools::COMPONENT_NAME, '', null, $debuginfo);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/invalid_status_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/invalid_status_exception.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Invalid status exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use local_ws_enrolcohort\tools;
+
+class invalid_status_exception extends \moodle_exception {
+    public function __construct($status = '') {
+        $a = ['enabled' => ENROL_INSTANCE_ENABLED, 'disabled' => ENROL_INSTANCE_DISABLED, 'actual' => $status];
+        parent::__construct('invalidstatus', tools::COMPONENT_NAME, '', null, tools::get_string('invalidstatus:message', $a));
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/not_available_at_context_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/not_available_at_context_exception.php
@@ -1,0 +1,42 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Not available at context exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use local_ws_enrolcohort\tools;
+
+class not_available_at_context_exception extends \moodle_exception {
+    public function __construct($object = '', $id = '', $word = '') {
+        // Prepare some strings and things.
+        $errorcode  = 'unavailableatcontext';
+        $a          = ['object' => $object, 'id' => $id, 'word' => $word];
+        $debuginfo  = tools::get_string('unavailableatcontext:message', $a);
+
+        parent::__construct($errorcode, tools::COMPONENT_NAME, '', null, $debuginfo);
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/object_not_found_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/object_not_found_exception.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Exception for an object that doesn't exist for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use \local_ws_enrolcohort\tools;
+
+class object_not_found_exception extends \moodle_exception {
+    public function __construct($object = '', $key = '', $value = '') {
+        $a = ['object' => $object, 'key' => $key, 'value' => $value];
+        parent::__construct('objectnotfound', tools::COMPONENT_NAME, '', null, tools::get_string('objectnotfound:message', $a));
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/role_not_assignable_at_context_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/role_not_assignable_at_context_exception.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Role not assignable at context exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class role_not_assignable_at_context_exception extends not_available_at_context_exception {
+    public function __construct($id = '') {
+        parent::__construct('Role', $id, 'assignable');
+    }
+}

--- a/local/ws_enrolcohort/classes/exceptions/role_not_found_exception.php
+++ b/local/ws_enrolcohort/classes/exceptions/role_not_found_exception.php
@@ -1,0 +1,35 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Role not found exception for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\exceptions;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class role_not_found_exception extends object_not_found_exception {
+    public function __construct($roleid = null) {
+        parent::__construct('role', 'id', $roleid);
+    }
+}

--- a/local/ws_enrolcohort/classes/privacy/provider.php
+++ b/local/ws_enrolcohort/classes/privacy/provider.php
@@ -1,0 +1,44 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy API provider for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\privacy;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use core_privacy\local\metadata\null_provider;
+
+class provider implements null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/local/ws_enrolcohort/classes/responses/base.php
+++ b/local/ws_enrolcohort/classes/responses/base.php
@@ -1,0 +1,43 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Base response for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+interface base {
+    /**
+     * base constructor.
+     */
+    public function __construct();
+
+    /**
+     * Returns the object as an array.
+     *
+     * @return mixed
+     */
+    public function to_array();
+}

--- a/local/ws_enrolcohort/classes/responses/cohort.php
+++ b/local/ws_enrolcohort/classes/responses/cohort.php
@@ -1,0 +1,67 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cohort response object for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class cohort extends response {
+    /**
+     * @var $name       The name of the cohort.
+     */
+    protected $name;
+
+    /**
+     * @var $idnumber   The idnumber of the cohort.
+     */
+    protected $idnumber;
+
+    /**
+     * @var $visible    The visibility of the cohort.
+     */
+    protected $visible;
+
+    /**
+     * cohort constructor.
+     *
+     * @param int $id
+     * @param string $object    The name of this object. Don't specify when constructing.
+     * @throws \dml_exception
+     */
+    public function __construct($id = 0, $object = 'cohort') {
+        global $DB;
+
+        parent::__construct($id, $object);
+
+        // Get the cohort.
+        $cohort = $DB->get_record('cohort', ['id' => $id]);
+
+        // Set the fields.
+        $this->name     = $cohort->name;
+        $this->idnumber = $cohort->idnumber;
+        $this->visible  = $cohort->visible;
+    }
+}

--- a/local/ws_enrolcohort/classes/responses/course.php
+++ b/local/ws_enrolcohort/classes/responses/course.php
@@ -1,0 +1,79 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Course response object for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class course extends response {
+    /**
+     * @var $name           The name of the course.
+     */
+    protected $name;
+
+    /**
+     * @var $idnumber       The idnumber of the course.
+     */
+    protected $idnumber;
+
+    /**
+     * @var $shortname      The shortname of the course.
+     */
+    protected $shortname;
+
+    /**
+     * @var $visible        Course visibility.
+     */
+    protected $visible;
+
+    /**
+     * @var $format         The format of the course.
+     */
+    protected $format;
+
+    /**
+     * course constructor.
+     *
+     * @param int $id
+     * @param string $object    The name of this object. Don't specify when constructing.
+     * @throws \dml_exception
+     */
+    public function __construct($id = 0, $object = 'course') {
+        global $DB;
+
+        parent::__construct($id, $object);
+
+        // Get the course.
+        $course = $DB->get_record('course', ['id' => $id]);
+
+        // Set the field values here.
+        $this->name         = $course->fullname;
+        $this->idnumber     = $course->idnumber;
+        $this->shortname    = $course->shortname;
+        $this->visible      = $course->visible;
+        $this->format       = $course->format;
+    }
+}

--- a/local/ws_enrolcohort/classes/responses/enrol.php
+++ b/local/ws_enrolcohort/classes/responses/enrol.php
@@ -1,0 +1,130 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Enrolment instance response object for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class enrol extends response {
+    /**
+     * @var $name           The name provided to the enrolment instance.
+     */
+    protected $name;
+
+    /**
+     * @var $status         The status of the enrolment instance.
+     */
+    protected $status;
+
+    /**
+     * @var $roleid         The id of the role associated to this enrolment instance.
+     */
+    protected $roleid;
+
+    /**
+     * @var $courseid       The id of the course this enrolment instance is for.
+     */
+    protected $courseid;
+
+    /**
+     * @var $cohortid       The id of the cohort.
+     */
+    protected $cohortid;
+
+    /**
+     * @var $groupid        The id of the group.
+     */
+    protected $groupid;
+
+    /**
+     * @var $course         More detail about the course associated to this enrolment instance.
+     */
+    protected $course;
+
+    /**
+     * @var $cohort         More detail about the cohort associated to this enrolment instance.
+     */
+    protected $cohort;
+
+    /**
+     * @var $role           More detail about the role associated to this enrolment instance.
+     */
+    protected $role;
+
+    /**
+     * @var $group          More detail about the group associated to this enrolment instance.
+     */
+    protected $group;
+
+    public function __construct($id = 0, $object = 'enrol', $name = '', $status = 0,
+                                $roleid = 0, $courseid = 0, $cohortid = 0, $groupid = 0) {
+        parent::__construct($id, $object);
+
+        // Set the values for the fields.
+        $this->name     = $name;
+        $this->status   = $status;
+        $this->roleid   = $roleid;
+        $this->courseid = $courseid;
+        $this->cohortid = $cohortid;
+        $this->groupid  = $groupid;
+    }
+
+    /**
+     * Set the details about the course for this enrolment method.
+     *
+     * @param $course
+     */
+    public function set_course($course) {
+        $this->course = $course;
+    }
+
+    /**
+     * Set the details about the cohort for this enrolment method.
+     *
+     * @param $cohort
+     */
+    public function set_cohort($cohort) {
+        $this->cohort = $cohort;
+    }
+
+    /**
+     * Set the details about the role for this enrolment method.
+     *
+     * @param $role
+     */
+    public function set_role($role) {
+        $this->role = $role;
+    }
+
+    /**
+     * Set the details about the group for this enrolment method.
+     *
+     * @param $group
+     */
+    public function set_group($group) {
+        $this->group = $group;
+    }
+}

--- a/local/ws_enrolcohort/classes/responses/error.php
+++ b/local/ws_enrolcohort/classes/responses/error.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Error response for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use \local_ws_enrolcohort\tools as tools;
+
+class error extends response {
+    /**
+     * @var string $message     A localized message with details about the error.
+     */
+    protected $message;
+
+    /**
+     * error constructor.
+     *
+     * @param int $id
+     * @param string $object                            The name of the object this error response is describing.
+     * @param string $identifier                        The langstring identifier. Only gets strings from this plugins lang file.
+     * @param string|\stdClass $langstringplaceholder   Any placeholder values for the lang string.
+     * @throws \coding_exception
+     * @throws \dml_exception
+     */
+    public function __construct($id = 0, $object = '', $identifier = '', $langstringplaceholder = null) {
+        parent::__construct($id, $object);
+
+        // Get a localized message.
+        $this->message = tools::get_string($identifier, $langstringplaceholder);
+    }
+}

--- a/local/ws_enrolcohort/classes/responses/group.php
+++ b/local/ws_enrolcohort/classes/responses/group.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Group response object for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+use local_ws_enrolcohort\tools;
+
+class group extends response {
+    /**
+     * @var $courseid   The id of the course this group belongs to.
+     */
+    protected $courseid;
+
+    /**
+     * @var $name       The name of the group.
+     */
+    protected $name;
+
+    /**
+     * group constructor.
+     *
+     * @param int $id               The id of the group.
+     * @param string $object        The name of this object. Don't specify when constructing.
+     * @param null|int $courseid    The id of the course. If null then the group creation errored.
+     * @throws \dml_exception
+     * @throws \coding_exception
+     */
+    public function __construct($id = 0, $object = 'group', $courseid = null) {
+        global $DB;
+
+        parent::__construct($id, $object);
+
+        // Set the fields.
+        $this->id = $id;
+
+        if (is_null($courseid) || $id == 0) {
+            $this->name     = tools::get_string('instancegroupnone');
+            $this->courseid = -1;
+        } else {
+            $this->name     = $DB->get_field('groups', 'name', ['id' => $id, 'courseid' => $courseid]);
+            $this->courseid = $courseid;
+        }
+    }
+}

--- a/local/ws_enrolcohort/classes/responses/response.php
+++ b/local/ws_enrolcohort/classes/responses/response.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Base response object for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+abstract class response implements base {
+
+    /**
+     * @var int $id             The id of the object this is representing.
+     */
+    protected $id;
+
+    /**
+     * @var string $object      The name of the object this is representing.
+     */
+    protected $object;
+
+    /**
+     * response constructor.
+     *
+     * @param int $id
+     * @param string $object
+     */
+    public function __construct($id = 0, $object = '') {
+        $this->id       = $id;
+        $this->object   = $object;
+    }
+
+    /**
+     * Return this response object as an array.
+     *
+     * @return array|mixed
+     */
+    public function to_array() {
+        $return = [];
+
+        foreach ($this as $key => $value) {
+            $return[$key] = $value;
+        }
+
+        return $return;
+    }
+}

--- a/local/ws_enrolcohort/classes/responses/role.php
+++ b/local/ws_enrolcohort/classes/responses/role.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Role response object for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort\responses;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class role extends response {
+    /**
+     * @var mixed $shortname    The shortname of the role.
+     */
+    protected $shortname;
+
+    /**
+     * role constructor.
+     *
+     * @param int $id           The id of the role.
+     * @param string $object    The name of this object. Don't specify when constructing.
+     * @throws \dml_exception
+     */
+    public function __construct($id = 0, $object = 'role') {
+        global $DB;
+
+        parent::__construct($id, $object);
+
+        // Get the shortname of this role from the database.
+        $this->shortname = $DB->get_field('role', 'shortname', ['id' => $id]);
+    }
+}

--- a/local/ws_enrolcohort/classes/tools.php
+++ b/local/ws_enrolcohort/classes/tools.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Classy locallib but not locallib for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_ws_enrolcohort;
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+class tools {
+    /**
+     * The plugins component name.
+     */
+    const COMPONENT_NAME = 'local_ws_enrolcohort';
+
+    /**
+     * @param string $identifier
+     * @param null $a
+     * @return string
+     * @throws \coding_exception
+     * @throws \dml_exception
+     */
+    public static function get_string($identifier = '', $a = null) {
+        // Get the string manager so we can do things.
+        $stringman = get_string_manager();
+
+        // Reset caches for our lang strings if it doesn't exist or forced plugin settings to reset lang string caches is set.
+        // Add to moodle config.php - $CFG->forced_plugin_settings = ['local_ws_enrolcohort' => ['resetlangstringcaches' => true]];.
+        if (!$stringman->string_exists($identifier, self::COMPONENT_NAME) || self::get_config('resetlangstringcaches')) {
+            $stringman->reset_caches();
+        }
+
+        if (is_null($a)) {
+            // No placeholder.
+            return get_string($identifier, self::COMPONENT_NAME);
+        } else {
+            // Yes placeholder.
+            return get_string($identifier, self::COMPONENT_NAME, $a);
+        }
+    }
+
+    /**
+     * Access this plugins settings.
+     *
+     * @param null $settingname     Omitting this parameter returns all plugin settings.
+     * @return mixed
+     * @throws \dml_exception
+     */
+    public static function get_config($settingname = null) {
+        return get_config(self::COMPONENT_NAME, $settingname);
+    }
+}

--- a/local/ws_enrolcohort/cli/upgrade.php
+++ b/local/ws_enrolcohort/cli/upgrade.php
@@ -1,0 +1,138 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Upgrade ws stuff. for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// This is a CLI script.
+define('CLI_SCRIPT', true);
+
+// Config file.
+require_once(dirname(dirname(dirname(dirname(__FILE__)))) . '/config.php');
+
+global $CFG;
+
+// Other things to require.
+require_once("{$CFG->libdir}/clilib.php");
+require_once("{$CFG->libdir}/cronlib.php");
+require_once("{$CFG->libdir}/upgradelib.php");
+
+// Get the locallib if we have one.
+if (file_exists("{$CFG->dirroot}/local/locallib.php")) {
+    require_once("{$CFG->dirroot}/local/locallib.php");
+}
+
+// We may need a lot of memory here.
+@set_time_limit(0);
+raise_memory_limit(MEMORY_HUGE);
+
+// CLI options.
+list($options, $unrecognized) = cli_get_params(
+    // Long names.
+    [
+        'help' => false,
+        'no-verbose' => false,
+        'no-debugging' => false,
+        'print-logo' => false
+    ],
+    // Short names.
+    [
+        'h' => 'help',
+        'nv' => 'no-verbose',
+        'nd' => 'no-debugging',
+        'pl' => 'print-logo'
+    ]
+);
+
+if (function_exists('cli_logo') && $options['print-logo']) {
+    // Show a logo because we can..
+    cli_logo();
+    echo PHP_EOL;
+}
+
+if ($unrecognized) {
+    $unrecognized = implode("\n ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+// Show help.
+if ($options['help']) {
+    $help =
+            "Local WS Enrol cohort CLI script to update things without updating things.
+
+Please note you must execute this script with the same uid as apache!
+
+Options:
+-nv, --no-verbose       Disables output to the console.
+-h, --help              Print out this help.
+-nd, --no-debugging     Disables debug messages.
+-pl, --print-logo       Prints a cool CLI logo if available.
+
+Example:
+Run script with default parameters  - \$sudo -u www-data /usr/bin/php upgrade.php\n
+";
+    echo $help;
+    die;
+}
+
+// Error checking.
+// Todo: Check any parameters that need stuff.
+
+// Set debugging.
+if (!$options['no-debugging']) {
+    @error_reporting(E_ALL | E_STRICT);
+    @ini_set('display_errors', '1');
+}
+
+// Start output log.
+$trace = new \text_progress_trace();
+$trace->output(get_string('pluginname', 'local_ws_enrolcohort').' - This is a CLI script that will update webservice things.');
+
+// Say some stuff like debugging is whatever.
+if (!$options['no-debugging']) {
+    $trace->output("Debugging is enabled.");
+} else {
+    $trace->output("Debugging has been disabled.");
+}
+
+// Set verbosity and output stuff.
+if ($options['no-verbose']) {
+    $trace->output("Verbose output has been disabled.\n");
+    $trace = new \null_progress_trace();
+} else {
+    $trace->output("Verbose output is enabled.\n");
+}
+
+// Non classy style of timing.
+$timenow = time();
+$trace->output("Server Time: " . date('r', $timenow) . "\n");
+$starttime = microtime();
+
+$trace->output('Updating the webservices without doing the moodle updateyness.');
+external_update_descriptions('local_ws_enrolcohort');
+$pluginman = \core_plugin_manager::instance();
+upgrade_noncore(true);
+$trace->output('The webservice functions stuff should be updated.'.PHP_EOL);
+
+// Finish timing.
+$difftime = microtime_diff($starttime, microtime());
+$trace->output("Script execution took {$difftime} seconds\n");

--- a/local/ws_enrolcohort/db/services.php
+++ b/local/ws_enrolcohort/db/services.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Definition of webservices for ws_enrolcohort.
+ *
+ * @package     ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+// The individual capabilities.
+$cohortview         = 'moodle/cohort:view';
+$roleassign         = 'moodle/role:assign';
+$coursemanagegroups = 'moodle/course:managegroups';
+$courseenrolconfig  = 'moodle/course:enrolconfig';
+$enrolcohortconfig  = 'enrol/cohort:config';
+
+// Put the capabilities together for each webservice function.
+$addcapabilities    = "{$cohortview}, {$roleassign}, {$coursemanagegroups}, {$courseenrolconfig}, {$enrolcohortconfig}";
+$updatecapabilities = "{$roleassign}, {$coursemanagegroups}, {$courseenrolconfig}, {$enrolcohortconfig}";
+$deletecapabilities = "{$cohortview}, {$coursemanagegroups}, {$courseenrolconfig}, {$enrolcohortconfig}";
+$getcapabilities    = "{$cohortview}, {$courseenrolconfig}, {$enrolcohortconfig}";
+
+// We defined the web service functions to install.
+$functions = [
+    'local_ws_enrolcohort_add_instance' => [
+        'classname'     => 'local_ws_enrolcohort_external',
+        'methodname'    => 'add_instance',
+        'classpath'     => 'local/ws_enrolcohort/externallib.php',
+        'description'   => 'Adds a new cohort sync enrolment instance to the specified course.',
+        'capabilities'  => $addcapabilities,
+        'type'          => 'create'
+    ],
+    'local_ws_enrolcohort_update_instance' => [
+        'classname'     => 'local_ws_enrolcohort_external',
+        'methodname'    => 'update_instance',
+        'classpath'     => 'local/ws_enrolcohort/externallib.php',
+        'description'   => 'Updates an existing cohort enrolment instance.',
+        'capabilities'  => $updatecapabilities,
+        'type'          => 'update'
+    ],
+    'local_ws_enrolcohort_delete_instance' => [
+        'classname'     => 'local_ws_enrolcohort_external',
+        'methodname'    => 'delete_instance',
+        'classpath'     => 'local/ws_enrolcohort/externallib.php',
+        'description'   => 'Deletes an existing cohort enrolment instance.',
+        'capabilities'  => $deletecapabilities,
+        'type'          => 'delete'
+    ],
+    'local_ws_enrolcohort_get_instances' => [
+        'classname'     => 'local_ws_enrolcohort_external',
+        'methodname'    => 'get_instances',
+        'classpath'     => 'local/ws_enrolcohort/externallib.php',
+        'description'   => 'Gets a list of cohort enrolment instances.',
+        'capabilities'  => $getcapabilities,
+        'type'          => 'get'
+    ]
+];
+
+// We define the services to install as pre-build services. A pre-build service is not editable by administrator.
+$services = [
+    'Extended webservice for enrol_cohort' => [
+        'functions'         => [
+            'local_ws_enrolcohort_add_instance',
+            'local_ws_enrolcohort_update_instance',
+            'local_ws_enrolcohort_delete_instance',
+            'local_ws_enrolcohort_get_instances'
+        ],
+        'restrictedusers'   => 1,
+        'enabled'           => 1,
+    ]
+];

--- a/local/ws_enrolcohort/externallib.php
+++ b/local/ws_enrolcohort/externallib.php
@@ -1,0 +1,959 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * stuff for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once("$CFG->libdir/externallib.php");
+
+use \local_ws_enrolcohort\tools;
+use \local_ws_enrolcohort\responses;
+
+use \local_ws_enrolcohort\exceptions\course_not_found_exception;
+use \local_ws_enrolcohort\exceptions\cohort_not_found_exception;
+use \local_ws_enrolcohort\exceptions\role_not_found_exception;
+use \local_ws_enrolcohort\exceptions\group_not_found_exception;
+use \local_ws_enrolcohort\exceptions\course_is_site_exception;
+use \local_ws_enrolcohort\exceptions\cohort_not_available_at_context_exception;
+use \local_ws_enrolcohort\exceptions\role_not_assignable_at_context_exception;
+use \local_ws_enrolcohort\exceptions\invalid_status_exception;
+use \local_ws_enrolcohort\exceptions\cohort_enrol_method_not_available_exception;
+use \local_ws_enrolcohort\exceptions\cohort_enrol_instance_already_synced_with_role_exception;
+use \local_ws_enrolcohort\exceptions\cohort_enrol_instance_not_found_exception;
+
+class local_ws_enrolcohort_external extends external_api {
+
+    /**
+     * Constants that define the query strings i.e. https://example.url?querystring[key]=value&querystring[key]=value etcetera.
+     */
+    const QUERYSTRING_INSTANCE  = 'instance';
+    const QUERYSTRING_COURSE    = 'course';
+
+    /**
+     * Constants that define group creation modes. Create group is already defined. Values are as per the add instance mform.
+     */
+    const COHORT_GROUP_CREATE_NONE = 0;
+    const COHORT_GROUP_CREATE_NEW = -1;
+
+    /**
+     * The value that says to the webservice function get_instances() to get all cohort enrolment instances.
+     */
+    const GET_INSTANCES_COURSEID_ALL = -1;
+
+    /**
+     * Constants that map the customint field names to the name of the fields.
+     */
+    const FIELD_GROUP   = 'customint2';
+    const FIELD_COHORT  = 'customint1';
+
+    /**
+     * A constant that defines a webservice function call that has errors.
+     */
+    const WEBSERVICE_FUNCTION_CALL_HAS_ERRORS_ID = -1;
+
+    /// <editor-fold desc="Other non webservice function specific functions that can be used internally.">
+
+    /**
+     * All the webservices functions defined in this external lib return the same stuff.
+     * This is some dry code.
+     *
+     * @return external_single_structure
+     */
+    public static function webservice_function_returns() {
+        return new external_single_structure([
+            'id'        => new external_value(PARAM_INT, 'The id of the enrolment instance'),
+            'code'      => new external_value(PARAM_INT, 'HTTP status code'),
+            'message'   => new external_value(PARAM_TEXT, 'Human readable response message'),
+            'data' => new external_multiple_structure(
+                new external_single_structure(
+                    [
+                        'object'    => new external_value(PARAM_TEXT, 'The object this is describing'),
+                        'id'        => new external_value(PARAM_INT, 'The id of the object', VALUE_OPTIONAL),
+                        'name'      => new external_value(PARAM_TEXT, 'The name of the object', VALUE_OPTIONAL),
+                        'courseid'  => new external_value(PARAM_INT, 'The id of the related course', VALUE_OPTIONAL),
+                        'cohortid'  => new external_value(PARAM_INT, 'The id of the cohort', VALUE_OPTIONAL),
+                        'roleid'    => new external_value(PARAM_INT, 'The id of the related role', VALUE_OPTIONAL),
+                        'groupid'   => new external_value(PARAM_INT, 'The id of the group', VALUE_OPTIONAL),
+                        'idnumber'  => new external_value(PARAM_RAW, 'The idnumber of the object', VALUE_OPTIONAL),
+                        'shortname' => new external_value(PARAM_TEXT, 'The shortname of the object', VALUE_OPTIONAL),
+                        'status'    => new external_value(PARAM_INT, 'The status of the object', VALUE_OPTIONAL),
+                        'active'    => new external_value(PARAM_TEXT, 'Enrolment instance is active or not', VALUE_OPTIONAL),
+                        'visible'   => new external_value(PARAM_INT, 'The visibility of the object', VALUE_OPTIONAL),
+                        'format'    => new external_value(PARAM_PLUGIN, 'The course format', VALUE_OPTIONAL)
+                    ],
+                    'extra details',
+                    VALUE_OPTIONAL
+                )
+            )
+        ]);
+    }
+
+    /**
+     * The functions get_instances and delete_instance will return the following structure that shows details of
+     * the cohort enrolment instance including the related course, cohort, role assigned, and group.
+     *
+     * @return external_single_structure
+     */
+    public static function webservice_function_enrolment_instance_returns() {
+        // Definition of extra details for course in get enrolment instance/s.
+        $coursedetails = new external_single_structure(
+            [
+                'object'    => new external_value(PARAM_TEXT, 'The type of object'),
+                'id'        => new external_value(PARAM_INT, 'The id of the course'),
+                'idnumber'  => new external_value(PARAM_RAW, 'The idnumber of the course'),
+                'name'      => new external_value(PARAM_TEXT, 'The name of the course'),
+                'shortname' => new external_value(PARAM_TEXT, 'The shortname of the course'),
+                'visible'   => new external_value(PARAM_INT, 'The visibility of the course'),
+                'format'    => new external_value(PARAM_PLUGIN, 'The course format')
+            ],
+            'More detail about the course associated to a cohort enrolment instance',
+            VALUE_OPTIONAL
+        );
+
+        // Definition of extra details for cohort in get enrolment instance/s.
+        $cohortdetails = new external_single_structure(
+            [
+                'object'    => new external_value(PARAM_TEXT, 'The type of object'),
+                'id'        => new external_value(PARAM_INT, 'The id of the cohort'),
+                'idnumber'  => new external_value(PARAM_RAW, 'The idnumber of the cohort'),
+                'name'      => new external_value(PARAM_TEXT, 'The name of the cohort'),
+                'visible'   => new external_value(PARAM_INT, 'The visibility of the cohort')
+            ],
+            'More detail about the course associated to a cohort enrolment instance',
+            VALUE_OPTIONAL
+        );
+
+        // Definition of extra details for role in get enrolment instance/s.
+        $roledetails = new external_single_structure(
+            [
+                'object'    => new external_value(PARAM_TEXT, 'The type of object'),
+                'id'        => new external_value(PARAM_INT, 'The id of the role'),
+                'shortname' => new external_value(PARAM_TEXT, 'The shortname of the role'),
+            ],
+            'More detail about the course associated to a cohort enrolment instance',
+            VALUE_OPTIONAL
+        );
+
+        // Definition of extra details for role in get enrolment instance/s.
+        $groupdetails = new external_single_structure(
+            [
+                'object'    => new external_value(PARAM_TEXT, 'The type of object'),
+                'id'        => new external_value(PARAM_INT, 'The id of the group'),
+                'courseid'  => new external_value(PARAM_INT, 'The id of the course this group belongs to'),
+                'name'      => new external_value(PARAM_TEXT, 'The name of the group'),
+            ],
+            'More detail about the course associated to a cohort enrolment instance',
+            VALUE_OPTIONAL
+        );
+
+        return new external_single_structure([
+            'id'        => new external_value(PARAM_INT, 'The id of the enrolment instance'),
+            'code'      => new external_value(PARAM_INT, 'HTTP status code'),
+            'message'   => new external_value(PARAM_TEXT, 'Human readable response message'),
+            'data' => new external_multiple_structure(
+                new external_single_structure(
+                    [
+                        'object'    => new external_value(PARAM_TEXT, 'The object this is describing'),
+                        'id'        => new external_value(PARAM_INT, 'The id of the object', VALUE_OPTIONAL),
+                        'name'      => new external_value(PARAM_TEXT, 'The name of the object', VALUE_OPTIONAL),
+                        'courseid'  => new external_value(PARAM_INT, 'The id of the related course', VALUE_OPTIONAL),
+                        'cohortid'  => new external_value(PARAM_INT, 'The id of the cohort', VALUE_OPTIONAL),
+                        'roleid'    => new external_value(PARAM_INT, 'The id of the related role', VALUE_OPTIONAL),
+                        'groupid'   => new external_value(PARAM_INT, 'The id of the group', VALUE_OPTIONAL),
+                        'idnumber'  => new external_value(PARAM_RAW, 'The idnumber of the object', VALUE_OPTIONAL),
+                        'shortname' => new external_value(PARAM_TEXT, 'The shortname of the object', VALUE_OPTIONAL),
+                        'status'    => new external_value(PARAM_INT, 'The status of the object', VALUE_OPTIONAL),
+                        'active'    => new external_value(PARAM_TEXT, 'Enrolment instance is active or not', VALUE_OPTIONAL),
+                        'visible'   => new external_value(PARAM_INT, 'The visibility of the object', VALUE_OPTIONAL),
+                        'format'    => new external_value(PARAM_PLUGIN, 'The course format', VALUE_OPTIONAL),
+                        'course'    => $coursedetails,
+                        'cohort'    => $cohortdetails,
+                        'role'      => $roledetails,
+                        'group'     => $groupdetails
+                    ],
+                    'extra details',
+                    VALUE_OPTIONAL
+                )
+            )
+        ]);
+    }
+
+    /**
+     * This function gets assignable roles for a course context.
+     *
+     * @param null $context
+     * @return array
+     */
+    public static function get_assignable_roles($context = null) {
+        return $context instanceof \context_course ? get_assignable_roles($context) : [];
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Functions for add_instance().">
+
+    /**
+     * Gets the default value for an add_instance() parameter. Use properly. No error checking happens.
+     *
+     * @param string $parametername
+     * @return mixed
+     */
+    public static function add_instance_get_parameter_default_value($parametername = '') {
+        // Just ask for the right things and one shall receive. We shan't be making any mistakes.
+        return self::add_instance_parameters()->keys[self::QUERYSTRING_INSTANCE]->keys[$parametername]->default;
+    }
+
+    /**
+     * Returns description of the add_instance function parameters.
+     *
+     * @return external_function_parameters
+     */
+    public static function add_instance_parameters() {
+        $courseidexternalvalue  = new external_value(
+            PARAM_INT, 'The id of the course.', VALUE_REQUIRED
+        );
+
+        $cohortidexternalvalue  = new external_value(
+            PARAM_INT, 'The id of the cohort.', VALUE_REQUIRED
+        );
+
+        $roleidexternalvalue    = new external_value(
+            PARAM_INT, 'The id of an existing role to assign users.', VALUE_REQUIRED
+        );
+
+        $groupidexternalvalue   = new external_value(
+            PARAM_INT, 'The id of a group to add users to.', VALUE_OPTIONAL, self::COHORT_GROUP_CREATE_NONE
+        );
+
+        $nameexternalvalue      = new external_value(
+            PARAM_TEXT, 'The name of the cohort enrolment instance.', VALUE_OPTIONAL, ''
+        );
+
+        $statusexternalvalue    = new external_value(
+            PARAM_INT, 'The status of the enrolment method.', VALUE_OPTIONAL, ENROL_INSTANCE_ENABLED
+        );
+
+        return new external_function_parameters([
+            self::QUERYSTRING_INSTANCE => new external_single_structure([
+                'courseid'  => $courseidexternalvalue,
+                'cohortid'  => $cohortidexternalvalue,
+                'roleid'    => $roleidexternalvalue,
+                'groupid'   => $groupidexternalvalue,
+                'name'      => $nameexternalvalue,
+                'status'    => $statusexternalvalue
+            ])
+        ]);
+    }
+
+    /**
+     * Returns description of the add_instance() function return value.
+     *
+     * @return external_single_structure
+     */
+    public static function add_instance_returns() {
+        return self::webservice_function_returns();
+    }
+
+    /**
+     * Adds a cohort enrolment instance to a given course.
+     *
+     * @param $params
+     * @return array
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function add_instance($params) {
+        global $CFG, $DB, $SITE;
+
+        require_once("{$CFG->dirroot}/cohort/lib.php");
+
+        // Check the call for parameters.
+        $params = self::validate_parameters(self::add_instance_parameters(), [self::QUERYSTRING_INSTANCE => $params]);
+
+        // Other data.
+        $extradata = [];
+
+        // Get the course.
+        $courseid = $params[self::QUERYSTRING_INSTANCE]['courseid'];
+
+        // Validate the course. This is required.
+        if ($courseid == $SITE->id) {
+            throw new course_is_site_exception();
+        } else if (!$DB->record_exists('course', ['id' => $courseid])) {
+            throw new course_not_found_exception($courseid);
+        }
+
+        // Set the context to course for validation.
+        $context = \context_course::instance($courseid);
+
+        // Add info to the response object.
+        $extradata[] = (new responses\course($courseid))->to_array();
+
+        // Get the cohort. This is required
+        $cohortid = $params[self::QUERYSTRING_INSTANCE]['cohortid'];
+
+        // Validate the cohort. This is required.
+        if (!$DB->record_exists('cohort', ['id' => $cohortid])) {
+            throw new cohort_not_found_exception($cohortid);
+        }
+
+        // Add some info to the response object.
+        $extradata[] = (new responses\cohort($cohortid))->to_array();
+
+        // Get the available cohorts.
+        $availablecohorts = cohort_get_available_cohorts($context, 0, 0, 0);
+        if (empty($availablecohorts) || !isset($availablecohorts[$cohortid])) {
+            throw new cohort_not_available_at_context_exception($cohortid);
+        }
+
+        // Get the role.
+        $roleid = $params[self::QUERYSTRING_INSTANCE]['roleid'];
+
+        // Validate the role. This is required.
+        $assignableroles = self::get_assignable_roles($context);
+
+        if (!$DB->record_exists('role', ['id' => $roleid])) {
+            // Role doesn't exist.
+            throw new role_not_found_exception($roleid);
+        } else if (empty($assignableroles) || !isset($assignableroles[$roleid])) {
+            // Role is not assignable at this context.
+            throw new role_not_assignable_at_context_exception($roleid);
+        }
+
+        $extradata[] = (new responses\role($roleid))->to_array();
+
+        // Get the group.
+        if (!isset($params[self::QUERYSTRING_INSTANCE]['groupid'])) {
+            $groupid = self::add_instance_get_parameter_default_value('groupid');
+        } else {
+            $groupid = $params[self::QUERYSTRING_INSTANCE]['groupid'];
+        }
+
+        // Validate the group. This is optional.
+        if (!is_null($groupid)) {
+            $groupcreatemodes = [self::COHORT_GROUP_CREATE_NONE, self::COHORT_GROUP_CREATE_NEW];
+            $coursegroupexists = $DB->record_exists('groups', ['courseid' => $courseid, 'id' => $groupid]);
+            if (!in_array($groupid, $groupcreatemodes) && !$coursegroupexists) {
+                // Provided group id doesn't exist for this course.
+                throw new group_not_found_exception($groupid);
+            }
+        } else {
+            // Get the default value specified for the parameter groupid.
+            $groupid = self::add_instance_get_parameter_default_value('groupid');
+        }
+
+        // Validate the name of the cohort enrolment instance. This is optional.
+        if (!isset($params[self::QUERYSTRING_INSTANCE]['name'])) {
+            $name = self::add_instance_get_parameter_default_value('name');
+        } else {
+            $name = $params[self::QUERYSTRING_INSTANCE]['name'];
+        }
+
+        // Check the users capabilities to ensure that they can do this.
+        if ($context instanceof \context_course) {
+            // Check that the user has the required capabilities for the course context. This may not be needed.
+            $requiredcapabilities = [
+                'moodle/course:enrolconfig',
+                'enrol/cohort:config',
+                'moodle/cohort:view',
+                'moodle/course:managegroups',
+                'moodle/role:assign'
+            ];
+
+            foreach ($requiredcapabilities as $requiredcapability) {
+                if (!has_capability($requiredcapability, $context)) {
+                    throw new required_capability_exception($context, $requiredcapability, 'nopermissions', '');
+                }
+            }
+        }
+
+        // Validate the status and set to a default.
+        if (!isset($params[self::QUERYSTRING_INSTANCE]['status'])) {
+            $status = self::add_instance_get_parameter_default_value('status');
+        } else {
+            $status = $params[self::QUERYSTRING_INSTANCE]['status'];
+        }
+
+        if (!is_null($status) && !in_array($status, [ENROL_INSTANCE_ENABLED, ENROL_INSTANCE_DISABLED])) {
+            throw new invalid_status_exception($status);
+        } else {
+            // Set status to the default.
+            $status = self::add_instance_get_parameter_default_value('status');
+        }
+
+        // This is the important one. Check if the cohort enrolment instance is available for use.
+        if (!$cohortenrolment = enrol_get_plugin('cohort')) {
+            throw new cohort_enrol_method_not_available_exception();
+        }
+
+        // Prepare the data to be returned as the response.
+        $extradata[] = [
+            'object'    => 'data',
+            'cohortid'  => $cohortid,
+            'roleid'    => $roleid,
+            'groupid'   => $groupid,
+            'name'      => $name,
+            'status'    => $status
+        ];
+
+        // We are anticipating a success.
+        $code = 201;
+        $message = tools::get_string('addinstance:201', $code);
+
+        // The initial response. The field id will be filled in later.
+        $response = [
+            'code'      => $code,
+            'message'   => $message,
+            'data'      => $extradata
+        ];
+
+        // Prepare the fields.
+        $fields = [
+            'name'              => $name,
+            'status'            => $status,
+            'roleid'            => $roleid,
+            'id'                => 0,
+            'courseid'          => $courseid,
+            'type'              => 'cohort',
+            self::FIELD_COHORT  => $cohortid,
+            self::FIELD_GROUP   => $groupid
+        ];
+
+        // Before creation ensure that there isn't an instance already synced with this role.
+        $sqlwhere = "roleid = :roleid AND customint1 = :customint1 AND courseid = :courseid AND enrol = 'cohort' AND id <> :id";
+        $sqlparams = [
+            'roleid'            => $roleid,
+            self::FIELD_COHORT  => $cohortid,
+            'courseid'          => $courseid,
+            'id'                => $fields['id']
+        ];
+
+        if ($DB->record_exists_select('enrol', $sqlwhere, $sqlparams)) {
+            // Don't add instance. Send an error response.
+            $instance = $DB->get_record_select('enrol', $sqlwhere, $sqlparams);
+
+            throw new cohort_enrol_instance_already_synced_with_role_exception($instance->id, $roleid);
+        }
+
+        // Get the full course object.
+        $course = $DB->get_record('course', ['id' => $courseid]);
+
+        // After all that hard work we can now add the instance.
+        $response['id'] = $cohortenrolment->add_instance($course, $fields);
+
+        // Get the enrolment instance.
+        $realenrolinstance = $DB->get_record('enrol', ['id' => $response['id']]);
+        if (empty($realenrolinstance->name)) {
+            $enrolinstancename =
+                $cohortenrolment->get_instance_name($realenrolinstance).' - '.tools::get_string('addinstance:usingdefaultname');
+        } else {
+            $enrolinstancename = $realenrolinstance->name;
+        }
+
+        // Add data about the group to the response.
+        $realgroupid = $DB->get_field('enrol', self::FIELD_GROUP, ['id' => $response['id']]);
+        $extradata[] = (new responses\group($realgroupid, 'group', $courseid))->to_array();
+
+        // Add data about the enrolment instance to the response.
+        $extradata[] = (new responses\enrol(
+            $response['id'], 'enrol', $enrolinstancename, $status, $roleid, $courseid, $cohortid, $realgroupid
+        ))->to_array();
+
+        // Add the additional extra data to the response.
+        $response['data'] = $extradata;
+
+        // Return some data.
+        return $response;
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Functions for update_instance().">
+
+    /**
+     * Gets the default value for an add_instance() parameter. Use properly. No error checking happens.
+     *
+     * @param string $parametername
+     * @return mixed
+     */
+    public static function update_instance_get_parameter_default_value($parametername = '') {
+        // Just ask for the right things and one shall receive. We shan't be making any mistakes.
+        return self::update_instance_parameters()->keys[self::QUERYSTRING_INSTANCE]->keys[$parametername]->default;
+    }
+
+    /**
+     * Returns description of the update_instance() function parameters.
+     *
+     * @return external_function_parameters
+     */
+    public static function update_instance_parameters() {
+        return new external_function_parameters([
+            self::QUERYSTRING_INSTANCE => new external_single_structure([
+                'id'      => new external_value(PARAM_INT, 'The id of the enrolment instance.', VALUE_REQUIRED),
+                'name'    => new external_value(PARAM_TEXT, 'The name you want to give the enrolment instance.', VALUE_OPTIONAL),
+                'status'  => new external_value(PARAM_INT, 'The status of the enrolment method.', VALUE_OPTIONAL),
+                'roleid'  => new external_value(PARAM_INT, 'The id of an existing role to assign users.', VALUE_OPTIONAL),
+                'groupid' => new external_value(PARAM_INT, 'The id of a group to add users to.', VALUE_OPTIONAL)
+            ])
+        ]);
+    }
+
+    /**
+     * Returns description of the update_instance function return value.
+     *
+     * @return external_single_structure
+     */
+    public static function update_instance_returns() {
+        return self::webservice_function_returns();
+    }
+
+    /**
+     * Updates an existing cohort enrolment instance.
+     *
+     * @param $params
+     * @return array
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function update_instance($params) {
+        global $DB, $SITE;
+
+        // Check the call for parameters.
+        $params = self::validate_parameters(self::update_instance_parameters(), [self::QUERYSTRING_INSTANCE => $params]);
+
+        // Other data.
+        $extradata = [];
+
+        // A place to put the updated enrolment data.
+        $data = new \stdClass();
+
+        // Preset the context.
+        $context = null;
+
+        // Get the enrolment instance id.
+        $id = $params[self::QUERYSTRING_INSTANCE]['id'];
+
+        // Validate the enrolment instance.
+        $sqlwhere = "enrol = 'cohort' AND id = :id AND courseid <> :courseid";
+        $sqlparams = ['id' => $id, 'courseid' => $SITE->id];
+
+        $enrolmentinstance = null;
+
+        if (!$DB->record_exists_select('enrol', $sqlwhere, $sqlparams)) {
+            throw new cohort_enrol_instance_not_found_exception($id);
+        } else {
+            $enrolmentinstance = $DB->get_record_select('enrol', $sqlwhere, $sqlparams);
+            $context = \context_course::instance($enrolmentinstance->courseid);
+        }
+
+        // Get the enrolment instance name.
+        if (!isset($params[self::QUERYSTRING_INSTANCE]['name'])) {
+            $name = $enrolmentinstance->name;
+        } else {
+            $name = $params[self::QUERYSTRING_INSTANCE]['name'];
+        }
+
+        if (!empty($name)) {
+            $data->name = $name;
+        }
+
+        // Get the enrolment instance status.
+        if (!isset($params[self::QUERYSTRING_INSTANCE]['status'])) {
+            $status = $enrolmentinstance->status;
+        } else {
+            $status = $params[self::QUERYSTRING_INSTANCE]['status'];
+        }
+
+        // Validate the enrolment instance status.
+        if (!is_null($status) && !in_array($status, [ENROL_INSTANCE_ENABLED, ENROL_INSTANCE_DISABLED])) {
+            throw new invalid_status_exception($status);
+        } else if (!is_null($status) && in_array($status, [ENROL_INSTANCE_ENABLED, ENROL_INSTANCE_DISABLED])) {
+            $data->status = $status;
+        }
+
+        // Get the enrolment instance role id.
+        if (!isset($params[self::QUERYSTRING_INSTANCE]['roleid'])) {
+            $roleid = $enrolmentinstance->roleid;
+        } else {
+            $roleid = $params[self::QUERYSTRING_INSTANCE]['roleid'];
+        }
+
+        if (!empty($roleid)) {
+            // Validate the role. This is required.
+            $assignableroles = self::get_assignable_roles($context);
+
+            if (!$DB->record_exists('role', ['id' => $roleid])) {
+                // Role doesn't exist.
+                throw new role_not_found_exception($roleid);
+            } else if (empty($assignableroles) || !isset($assignableroles[$roleid])) {
+                // Role is not assignable at this context.
+                throw new role_not_assignable_at_context_exception($roleid);
+            } else {
+                $data->roleid = $roleid;
+            }
+        }
+
+        // Get the group id.
+        if (!isset($params[self::QUERYSTRING_INSTANCE]['groupid'])) {
+            $groupid = $enrolmentinstance->{self::FIELD_GROUP};
+        } else {
+            $groupid = $params[self::QUERYSTRING_INSTANCE]['groupid'];
+        }
+        // Validate the group id.
+        if (!empty($groupid)) {
+            $groupcreatemodes = [self::COHORT_GROUP_CREATE_NONE, self::COHORT_GROUP_CREATE_NEW];
+            $groupexistsforcourse = $DB->record_exists('groups', ['courseid' => $enrolmentinstance->courseid, 'id' => $groupid]);
+            if (!in_array($groupid, $groupcreatemodes) && !is_null($enrolmentinstance) && !$groupexistsforcourse) {
+                // Provided group id doesn't exist for this course.
+                throw new group_not_found_exception($groupid);
+            }
+        }
+
+        $data->{self::FIELD_GROUP} = $groupid;
+
+        // Return the supplied parameters.
+        $extradata[] = [
+            'id'        => $id,
+            'object'    => 'params',
+            'roleid'    => $roleid,
+            'name'      => $name,
+            'status'    => $status,
+            'groupid'   => $groupid
+        ];
+
+        // Check for things that are the same.
+        if ($enrolmentinstance instanceof \stdClass && $context instanceof \context_course) {
+            foreach ($data as $property => $value) {
+                if (isset($enrolmentinstance->$property) && $enrolmentinstance->$property != $value) {
+                    // Add role detail to the response object.
+                    if (\core_text::strtolower($property) == 'roleid') {
+                        $extradata[] = (new responses\role($value))->to_array();
+                    }
+                }
+            }
+        }
+
+        // This is the important one. Check if the cohort enrolment instance is available for use.
+        if (!$cohortenrolment = enrol_get_plugin('cohort')) {
+            throw new cohort_enrol_method_not_available_exception();
+        }
+
+        // Check the params passed aka only id is passed
+        $noupdations = count($params[self::QUERYSTRING_INSTANCE]) === 1 && isset($params[self::QUERYSTRING_INSTANCE]['id']);
+
+        // Response message.
+        if ($noupdations) {
+            $message = tools::get_string('updateinstance:nochange');
+        } else {
+            $message = tools::get_string('updateinstance:200');
+
+            // Add the cohort id to the data.
+            $data->{self::FIELD_COHORT} = $enrolmentinstance->{self::FIELD_COHORT};
+
+            $previousgroupid = $enrolmentinstance->{self::FIELD_GROUP};
+
+            // Haven't even updated the enrolment instance and we are celebrating.
+            $cohortenrolment->update_instance($enrolmentinstance, $data);
+
+            // Add the course to the response object.
+            $extradata[] = (new responses\course($enrolmentinstance->courseid))->to_array();
+
+            // Add the cohort detail to the response object.
+            $extradata[] = (new responses\cohort($enrolmentinstance->{self::FIELD_COHORT}))->to_array();
+
+            // Get the new group and add to the response object.
+            if ($groupid == COHORT_CREATE_GROUP) {
+                $extradata[] = (new responses\group($data->{self::FIELD_GROUP}, 'group', $enrolmentinstance->courseid))->to_array();
+            } else if ($groupid != $previousgroupid) {
+                $extradata[] = (new responses\group($groupid, 'group', $enrolmentinstance->courseid))->to_array();
+            }
+
+            // Add detail about the enrolment instance.
+            $extradata[] = (new responses\enrol(
+                $id,
+                'enrol',
+                $enrolmentinstance->name,
+                $enrolmentinstance->status,
+                $enrolmentinstance->roleid,
+                $enrolmentinstance->courseid,
+                $enrolmentinstance->{self::FIELD_COHORT},
+                $enrolmentinstance->{self::FIELD_GROUP}
+            ))->to_array();
+        }
+
+        // The HTTP status code.
+        $code = 200;
+
+        // Prepare the response.
+        $response = [
+            'id'        => $id,
+            'code'      => $code,
+            'message'   => $message,
+            'data'      => $extradata
+        ];
+
+        return $response;
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Functions for delete_instance().">
+
+    /**
+     * Returns description of the delete_instance() function parameters.
+     *
+     * @return external_function_parameters
+     */
+    public static function delete_instance_parameters() {
+        return new external_function_parameters([
+            self::QUERYSTRING_INSTANCE => new external_single_structure([
+                'id' => new external_value(PARAM_INT, 'The id of the enrolment instance to delete.', VALUE_REQUIRED)
+            ])
+        ]);
+    }
+
+    /**
+     * Returns description of the delete_instance() function return value.
+     *
+     * @return external_single_structure
+     */
+    public static function delete_instance_returns() {
+        return self::webservice_function_enrolment_instance_returns();
+    }
+
+    /**
+     * Deletes a cohort enrolment instance.
+     *
+     * @param $params
+     * @return array
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function delete_instance($params) {
+        global $DB;
+
+        // Check the parameters.
+        $params = self::validate_parameters(self::delete_instance_parameters(), [self::QUERYSTRING_INSTANCE => $params]);
+
+        $extradata = [];
+
+        // Get the enrolment instance id.
+        $id = $params[self::QUERYSTRING_INSTANCE]['id'];
+
+        // Validate the enrolment instance id.
+        if (!$DB->record_exists('enrol', ['id' => $id, 'enrol' => 'cohort'])) {
+            throw new cohort_enrol_instance_not_found_exception($id);
+        }
+
+        // This is the important one. Check if the cohort enrolment instance is available for use.
+        if (!$cohortenrolment = enrol_get_plugin('cohort')) {
+            throw new cohort_enrol_method_not_available_exception();
+        }
+
+        // Set the HTTP response code.
+        $code = 200;
+
+        // Get the enrolment instance Nelly ;).
+        $ei = $DB->get_record('enrol', ['id' => $id, 'enrol' => 'cohort']);
+
+        // Make a E.I. response.
+        $eiresponse = new responses\enrol(
+            $id, 'enrol', $ei->name, $ei->status, $ei->roleid, $ei->courseid, $ei->{self::FIELD_COHORT}, $ei->{self::FIELD_GROUP}
+        );
+
+        // Get other details about the deleted enrolment instance.
+        $eiresponse->set_course((new responses\course($ei->courseid))->to_array());
+        $eiresponse->set_cohort((new responses\cohort($ei->{self::FIELD_COHORT}))->to_array());
+        $eiresponse->set_role((new responses\role($ei->roleid))->to_array());
+        $eiresponse->set_group((new responses\group($ei->{self::FIELD_GROUP}, 'group', $ei->courseid))->to_array());
+
+        // Add the E.I. to the response.
+        $extradata[] = $eiresponse->to_array();
+
+        // Actuals delete the enrolment instance.
+        $cohortenrolment->delete_instance($ei);
+
+        // The following is a message of success.
+        $message = tools::get_string('deleteinstance:200');
+
+        // Prepare the response and then send it.
+        $response = [
+            'id'        => $id,
+            'code'      => $code,
+            'message'   => $message,
+            'data'      => $extradata
+        ];
+
+        return $response;
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Functions for get_instances().">
+
+    /**
+     * Returns description of the get_instances() function return value.
+     *
+     * @return external_function_parameters
+     */
+    public static function get_instances_parameters() {
+        return new external_function_parameters([
+            self::QUERYSTRING_COURSE => new external_single_structure([
+                'id' => new external_value(PARAM_INT, 'The id of a course to get enrolment instances for.', VALUE_REQUIRED)
+            ])
+        ]);
+    }
+
+    /**
+     * Returns description of the get_instances() function return value.
+     *
+     * @return external_single_structure
+     */
+    public static function get_instances_returns() {
+        return self::webservice_function_enrolment_instance_returns();
+    }
+
+    /**
+     * Gets the enrolment instances for a course or the entire site.
+     *
+     * @param $params
+     * @return array
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws invalid_parameter_exception
+     * @throws moodle_exception
+     */
+    public static function get_instances($params) {
+        global $DB, $SITE;
+
+        // Check the parameters.
+        $params = self::validate_parameters(self::get_instances_parameters(), [self::QUERYSTRING_COURSE => $params]);
+
+        $extradata = [];
+
+        // Get the courseid aka id.
+        $courseid = $params[self::QUERYSTRING_COURSE]['id'];
+
+        // Validate the courseid.
+        if ($courseid == $SITE->id) {
+            throw new course_is_site_exception();
+        } else if (!$DB->record_exists('course', ['id' => $courseid]) && $courseid != -1) {
+            throw new course_not_found_exception($courseid);
+        }
+
+        // Get the courses.
+        if ($courseid == self::GET_INSTANCES_COURSEID_ALL) {
+            $courses = $DB->get_records('course');
+        } else {
+            $courses = $DB->get_records('course', ['id' => $courseid]);
+        }
+
+        $foundsitecourse = false;
+        $numberofenrolmentmethods = 0;
+
+        foreach ($courses as $course) {
+            // Skip the site course.
+            if ($course->id == $SITE->id) {
+                $foundsitecourse = true;
+                continue;
+            }
+
+            // Skip courses that don't have cohort enrolment methods.
+            if (!$DB->record_exists('enrol', ['enrol' => 'cohort', 'courseid' => $course->id])) {
+                continue;
+            }
+
+            // Get the cohort enrolment instances for this course.
+            $enrolmentinstances = $DB->get_records('enrol', ['enrol' => 'cohort', 'courseid' => $course->id]);
+
+            foreach ($enrolmentinstances as $enrolmentinstance) {
+                // Make some info about the enrolment instance.
+                $ei = new responses\enrol(
+                    $enrolmentinstance->id,
+                    'enrol',
+                    $enrolmentinstance->name,
+                    $enrolmentinstance->status,
+                    $enrolmentinstance->roleid,
+                    $enrolmentinstance->courseid,
+                    $enrolmentinstance->{self::FIELD_COHORT},
+                    $enrolmentinstance->{self::FIELD_GROUP}
+                );
+
+                // Get other details about the enrolment instance.
+                $ei->set_course((new responses\course($enrolmentinstance->courseid))->to_array());
+                $ei->set_cohort((new responses\cohort($enrolmentinstance->{self::FIELD_COHORT}))->to_array());
+                $ei->set_role((new responses\role($enrolmentinstance->roleid))->to_array());
+
+                // Made an object for this so it doesn't exceed 132 characters.
+                $groupresponse = new responses\group(
+                    $enrolmentinstance->{self::FIELD_GROUP}, 'group', $enrolmentinstance->courseid
+                );
+
+                $ei->set_group($groupresponse->to_array());
+
+                $extradata[] = $ei->to_array();
+
+                $numberofenrolmentmethods += 1;
+            }
+        }
+
+        // Count things and make langstring placeholders.
+        $numberofcourses = count($courses);
+        if ($foundsitecourse) {
+            $numberofcourses -= 1;
+        }
+
+        $a = [
+            'courseid'                      => $courseid,
+            'numberofenrolmentinstances'    => $numberofenrolmentmethods,
+            'numberofcourses'               => $numberofcourses
+        ];
+
+        if ($courseid == self::GET_INSTANCES_COURSEID_ALL) {
+            $message = tools::get_string('getinstances:200', $a);
+        } else {
+            $message = tools::get_string('getinstance:200', $a);
+        }
+
+        // Prepare the response.
+        $response = [
+            'id'        => $courseid,
+            'code'      => 200,
+            'message'   => $message,
+            'data'      => $extradata
+        ];
+
+        return $response;
+    }
+
+    /// </editor-fold>
+}

--- a/local/ws_enrolcohort/lang/en/local_ws_enrolcohort.php
+++ b/local/ws_enrolcohort/lang/en/local_ws_enrolcohort.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for language 'en' for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+// Default langstring.
+$string['pluginname'] = 'Extended enrol cohort webservices';
+
+// Strings for course stuff.
+$string['coursenotexists']  = 'Course does not exist.';
+
+// Strings for cohort stuff.
+$string['cohortnotexists']              = 'Cohort does not exist.';
+$string['cohortnotavailableatcontext']  = 'Cohort cannot be added to this course.';
+$string['cohortnullcontext']            = 'Cohort cannot be added because the context is null.';
+
+// Strings for role stuff.
+$string['rolenotexists']            = 'Role does not exist.';
+$string['rolenotassignablehere']    = 'Role is not assignable here.';
+
+// Strings for group stuff.
+$string['groupnotexists']   = 'Group does not exist.';
+
+// Strings for capabilities stuff.
+$string['usermissingrequiredcapability']    = 'User is missing the required capability \'{$a}\' at the course context.';
+$string['usermissinganycapability']         = 'User is missing one of the following capabilities at the course context: {$a}.';
+
+// Strings for enrolment method stuff.
+$string['enrolmentmethodnotavailable']  = 'Could not instantiate enrol_cohort.';
+
+// Strings for status stuff.
+$string['statusinvalid'] = 'Invalid status {$a}. Possible statuses are: 0 - active, 1 - not active.';
+
+// Strings for instance.
+$string['instancegroupnone']    = 'Enrol instance group none.';
+$string['instancenotexists']    = 'Unknown enrolment instance.';
+
+// Strings for webservice function add_instance.
+$string['addinstance:201']              = 'Cohort enrolment instance added.';
+$string['addinstance:400']              = 'Could not add cohort enrolment instance.';
+$string['addinstance:usingdefaultname'] = 'Using system generated name.';
+$string['addinstance:courseissite']     = 'Can not add instance to the site course.';
+
+// Strings for webservice function update_instance.
+$string['updateinstance:200'] = 'Cohort enrolment instance updated.';
+$string['updateinstance:400'] = 'Could not update cohort enrolment instance.';
+$string['updateinstance:nochange'] = 'No changes were made to the cohort enrolment instance.';
+
+// Strings for webservice function delete_instance.
+$string['deleteinstance:200'] = 'Cohort enrolment instance deleted.';
+$string['deleteinstance:400'] = 'Could not delete cohort enrolment instance.';
+
+// Strings for webservice function get_instances.
+$string['getinstance:200'] = 'Found {$a->numberofenrolmentinstances} cohort enrolment instances for the course with id {$a->courseid}.';
+$string['getinstances:200'] = 'Found {$a->numberofenrolmentinstances} cohort enrolment instances in {$a->numberofcourses} courses (All courses).';
+$string['getinstances:400'] = 'Could not get cohort enrolment instances.';
+$string['getinstances:courseissite']    = 'Can not get instances for the site course.';
+
+// String for an unknown HTTP status code.
+$string['unknownstatuscode'] = 'Unknown status code {$a}.';
+
+// Strings for exceptions.
+$string['objectnotfound']               = 'Object does not exist!';
+$string['objectnotfound:message']       = 'Could not find {$a->object} with {$a->key} {$a->value}';
+$string['invalidcourse']                = 'Course is invalid!';
+$string['invalidcourse:issite']         = 'Can not add instance to the site course.';
+$string['unavailableatcontext']         = 'Object is not available at this context!';
+$string['unavailableatcontext:message'] = '{$a->object} with id {$a->id} is not {$a->word} at this context.';
+$string['invalidstatus']                = 'Invalid enrolment instance status!';
+$string['invalidstatus:message']        = 'Possible values for enrolment instance status are: {$a->enabled} - Enabled, {$a->disabled} - Disabled. Got {$a->actual}.';
+$string['cohortenrolmethodnotavailable']    = 'The cohort enrolment method is not available.';
+$string['enrolcohortalreadysyncedwithrole']         = 'A cohort enrol instance for this role already exists';
+$string['enrolcohortalreadysyncedwithrole:message'] = 'A cohort enrol instance with id {$a->enrolid} is already synchronised with the role {$a->roleid}';
+
+// Strings for privacy API.
+$string['privacy:metadata'] = 'The local webservices cohort enrolment plugin does not store any personal data.';

--- a/local/ws_enrolcohort/tests/externallib_test.php
+++ b/local/ws_enrolcohort/tests/externallib_test.php
@@ -1,0 +1,1195 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Cohort enrolment webservice tests for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+
+require_once($CFG->dirroot.'/webservice/tests/helpers.php');
+require_once($CFG->dirroot.'/local/ws_enrolcohort/externallib.php');
+
+use \local_ws_enrolcohort\tools;
+
+class local_ws_enrolcohort_externallib_testcase extends externallib_advanced_testcase {
+    public function create_cohorts($numberofcohorts = 100) {
+        for ($i = 0; $i < $numberofcohorts; $i++) {
+            self::getDataGenerator()->create_cohort();
+        }
+    }
+
+    /// <editor-fold desc="Tests for get_instances() function calls.">
+
+    public function test_get_instances() {
+        global $SITE, $DB;
+
+        // Test getting enrolment instances for the site course.
+        try {
+            local_ws_enrolcohort_external::get_instances(['id' => $SITE->id]);
+            $this->fail('Expected a course_is_site_exception to be thrown.');
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\course_is_site_exception', $exception);
+            $this->assertEquals('invalidcourse', $exception->errorcode);
+        }
+
+        // Test getting enrolment instances for acourse that doesn't exist.
+        try {
+            local_ws_enrolcohort_external::get_instances(['id' => 999]);
+            $this->fail('Expected a course_not_found_exception to be thrown.');
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\course_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        // Make courses and stuff for adding enrolment instances to.
+
+        $this->resetAfterTest(true);
+
+        // The number of courses, and cohort enrolment instances to make.
+        $numberofcoursestomake = 5;
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        // Storage for courseids.
+        $courseids = [];
+
+        $this->setAdminUser();
+
+        for ($i = 0; $i < $numberofcoursestomake; $i++) {
+            $course = self::getDataGenerator()->create_course();
+            $cohort = self::getDataGenerator()->create_cohort();
+
+            $roleid = self::getDataGenerator()->create_role();
+
+            $courseid   = $course->id;
+            $cohortid   = $cohort->id;
+
+            $courseids[] = $courseid;
+
+            // Add a cohort enrolment instance to a course.
+            try {
+                $wsenrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                    'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+                ]);
+            } catch (moodle_exception $exception) {
+                // This should never happen.
+                $this->fail('An exception was caught ('.get_class($exception).').');
+            }
+
+            // The first call to add an enrolment instance should never be null.
+            $this->assertNotNull($wsenrolmentinstance);
+
+            // Validate and then get the enrol instance id.
+            $this->arrayHasKey('id', $wsenrolmentinstance);
+            $this->assertGreaterThan(0, $wsenrolmentinstance['id']);
+        }
+
+        // Add the id of the course to get all enrolment methods.
+        $courseids[] = -1;
+
+        foreach ($courseids as $key => $courseid) {
+            try {
+                $enrolmentinstances = local_ws_enrolcohort_external::get_instances(['id' => $courseid]);
+            } catch (moodle_exception $exception) {
+                $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+            }
+        }
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for delete_instance() function calls. ">
+
+    public function test_delete_instance() {
+        $this->resetAfterTest(true);
+
+        $wsenrolmentinstance  = null;
+        $response           = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        // Add a cohort enrolment instance to a course.
+        try {
+            $wsenrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // The first call to add an enrolment instance should never be null.
+        $this->assertNotNull($wsenrolmentinstance);
+
+        // Validate and then get the enrol instance id.
+        $this->arrayHasKey('id', $wsenrolmentinstance);
+        $this->assertGreaterThan(0, $wsenrolmentinstance['id']);
+
+        $enrolmentinstanceid = $wsenrolmentinstance['id'];
+
+        $wsdeleteinstanceresponse = null;
+
+        // Delete an enrolment instance that doesn't exist.
+        try {
+            local_ws_enrolcohort_external::delete_instance(['id' => 118]);
+            $this->fail('Expected a cohort_enrol_instance_not_found exception to be thrown.');
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\cohort_enrol_instance_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        // Delete an enrolment instance that does exist.
+        try {
+            $wsdeleteinstanceresponse = local_ws_enrolcohort_external::delete_instance(['id' => $enrolmentinstanceid]);
+        } catch (moodle_exception $exception) {
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        $enrolmentinstances = enrol_get_instances($course->id, false);
+        $this->assertArrayNotHasKey($enrolmentinstanceid, $enrolmentinstances);
+
+        $this->assertArrayHasKey('id', $wsdeleteinstanceresponse);
+        $this->assertEquals($enrolmentinstanceid, $wsdeleteinstanceresponse['id']);
+
+        $this->assertArrayHasKey('code', $wsdeleteinstanceresponse);
+        $this->assertEquals(200, $wsdeleteinstanceresponse['code']);
+
+        $this->assertArrayHasKey('message', $wsdeleteinstanceresponse);
+        $this->assertEquals(tools::get_string('deleteinstance:200'), $wsdeleteinstanceresponse['message']);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for update_instance() function calls.">
+
+    /// <editor-fold desc="Tests for invalid function calls to update_instance().">
+
+    public function test_update_instance_enrol_instance_id_not_found() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance(['id' => 1]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\cohort_enrol_instance_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_update_instance_invalid_status() {
+        $this->resetAfterTest(true);
+
+        $enrolmentinstance  = null;
+        $response           = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+
+        // Add a cohort enrolment instance to a course.
+        try {
+            $enrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // The first call to add an enrolment instance should never be null.
+        $this->assertNotNull($enrolmentinstance);
+
+        // Validate and then get the enrol instance id.
+        $this->arrayHasKey('id', $enrolmentinstance);
+        $this->assertGreaterThan(0, $enrolmentinstance['id']);
+        $enrolmentinstanceid = $enrolmentinstance['id'];
+
+        try {
+            // A status of 1000 is not a valid status.
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'status' => 1000
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\invalid_status_exception', $exception);
+            $this->assertEquals('invalidstatus', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_update_instance_role_not_found() {
+        $this->resetAfterTest(true);
+
+        $enrolmentinstance  = null;
+        $response           = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+
+        // Add a cohort enrolment instance to a course.
+        try {
+            $enrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // The first call to add an enrolment instance should never be null.
+        $this->assertNotNull($enrolmentinstance);
+
+        // Validate and then get the enrol instance id.
+        $this->arrayHasKey('id', $enrolmentinstance);
+        $this->assertGreaterThan(0, $enrolmentinstance['id']);
+        $enrolmentinstanceid = $enrolmentinstance['id'];
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'roleid' => 999
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\role_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_update_instance_role_not_assignable() {
+        $this->resetAfterTest(true);
+
+        $enrolmentinstance  = null;
+        $response           = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+
+        // Add a cohort enrolment instance to a course.
+        try {
+            $enrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // The first call to add an enrolment instance should never be null.
+        $this->assertNotNull($enrolmentinstance);
+
+        // Validate and then get the enrol instance id.
+        $this->arrayHasKey('id', $enrolmentinstance);
+        $this->assertGreaterThan(0, $enrolmentinstance['id']);
+        $enrolmentinstanceid = $enrolmentinstance['id'];
+
+        $unassignableroleid = self::getDataGenerator()->create_role(['archetype' => 'frontpage']);
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'roleid' => $unassignableroleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\role_not_assignable_at_context_exception', $exception);
+            $this->assertEquals('unavailableatcontext', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_update_instance_group_not_found() {
+        $this->resetAfterTest(true);
+
+        $enrolmentinstance  = null;
+        $response           = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+
+        // Add a cohort enrolment instance to a course.
+        try {
+            $enrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // The first call to add an enrolment instance should never be null.
+        $this->assertNotNull($enrolmentinstance);
+
+        // Validate and then get the enrol instance id.
+        $this->arrayHasKey('id', $enrolmentinstance);
+        $this->assertGreaterThan(0, $enrolmentinstance['id']);
+        $enrolmentinstanceid = $enrolmentinstance['id'];
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'groupid' => 1234
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('\local_ws_enrolcohort\exceptions\group_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for update_instance() success.">
+
+    public function test_update_instance_nochange() {
+        $this->resetAfterTest(true);
+
+        $enrolmentinstance  = null;
+        $response           = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+
+        // Add a cohort enrolment instance to a course.
+        try {
+            $enrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // The first call to add an enrolment instance should never be null.
+        $this->assertNotNull($enrolmentinstance);
+
+        // Validate and then get the enrol instance id.
+        $this->arrayHasKey('id', $enrolmentinstance);
+        $this->assertGreaterThan(0, $enrolmentinstance['id']);
+        $enrolmentinstanceid = $enrolmentinstance['id'];
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        $this->assertArrayHasKey('id', $response);
+        $this->assertEquals($enrolmentinstanceid, $response['id']);
+
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(200, $response['code']);
+
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('updateinstance:nochange'), $response['message']);
+
+        $this->assertArrayHasKey('data', $response);
+        $this->assertEquals(1, count($response['data']));
+    }
+
+    public function test_update_instance() {
+        global $DB;
+
+        $this->resetAfterTest(true);
+
+        $enrolmentinstance  = null;
+        $response           = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+
+        // Add a cohort enrolment instance to a course.
+        try {
+            $enrolmentinstance = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // The first call to add an enrolment instance should never be null.
+        $this->assertNotNull($enrolmentinstance);
+
+        // Validate and then get the enrol instance id.
+        $this->arrayHasKey('id', $enrolmentinstance);
+        $this->assertGreaterThan(0, $enrolmentinstance['id']);
+        $enrolmentinstanceid = $enrolmentinstance['id'];
+
+        // Change the role.
+        $newroleid = self::getDataGenerator()->create_role();
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'roleid' => $newroleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        $this->assertArrayHasKey('id', $response);
+        $this->assertEquals($enrolmentinstanceid, $response['id']);
+
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(200, $response['code']);
+
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('updateinstance:200'), $response['message']);
+
+        // Check roleid.
+        $this->assertEquals($DB->get_field('enrol', 'roleid', ['id' => $enrolmentinstanceid]), $newroleid);
+
+        // Change the group.
+        $newgroup = self::getDataGenerator()->create_group(['courseid' => $courseid]);
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'groupid' => $newgroup->id
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        $this->assertArrayHasKey('id', $response);
+        $this->assertEquals($enrolmentinstanceid, $response['id']);
+
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(200, $response['code']);
+
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('updateinstance:200'), $response['message']);
+
+        // Check groupid.
+        $currentgroupid = $DB->get_field('enrol', local_ws_enrolcohort_external::FIELD_GROUP, ['id' => $enrolmentinstanceid]);
+        $this->assertEquals($currentgroupid, $newgroup->id);
+
+        // Change the name.
+        $newname = 'This is a brand new name';
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'name' => $newname
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        $this->assertArrayHasKey('id', $response);
+        $this->assertEquals($enrolmentinstanceid, $response['id']);
+
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(200, $response['code']);
+
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('updateinstance:200'), $response['message']);
+
+        // Check name updation.
+        $this->assertEquals($DB->get_field('enrol', 'name', ['id' => $enrolmentinstanceid]), $newname);
+
+        // Change the status.
+        $newstatus = ENROL_INSTANCE_DISABLED;
+
+        try {
+            $response = local_ws_enrolcohort_external::update_instance([
+                'id' => $enrolmentinstanceid, 'status' => $newstatus
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        $this->assertArrayHasKey('id', $response);
+        $this->assertEquals($enrolmentinstanceid, $response['id']);
+
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(200, $response['code']);
+
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('updateinstance:200'), $response['message']);
+
+        // Check status.
+        $this->assertEquals($DB->get_field('enrol', 'status', ['id' => $enrolmentinstanceid]), $newstatus);
+    }
+
+    /// </editor-fold>
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for add_instance() function calls.">
+
+    /// <editor-fold desc="Tests for successful add_instance() function calls.">
+
+    public function test_add_instance_success_without_group() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid = $course->id;
+        $cohortid = $cohort->id;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // Validate the response code.
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(201, $response['code']);
+
+        // Validate the response message.
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('addinstance:201'), $response['message']);
+
+        // Validate the response data.
+        $responsedatahas = [];
+
+        foreach ($response['data'] as $key => $responsedata) {
+            $this->assertArrayHasKey('object', $responsedata);
+
+            if (!$responsedata['object'] == 'data') {
+                $this->assertArrayHasKey('id', $responsedata);
+            }
+
+            $responsedatahas[$responsedata['object']] = $key;
+        }
+
+        $this->assertArrayHasKey('course', $responsedatahas);
+        $this->assertArrayHasKey('cohort', $responsedatahas);
+        $this->assertArrayHasKey('role', $responsedatahas);
+        $this->assertArrayHasKey('data', $responsedatahas);
+        $this->assertArrayHasKey('group', $responsedatahas);
+        $this->assertEquals(0, $response['data'][$responsedatahas['group']]['id']);
+        $this->assertArrayHasKey('enrol', $responsedatahas);
+        $this->assertEquals(6, count($response['data']));
+
+        // Validate the response id.
+        $this->assertArrayHasKey('id', $response);
+        $this->assertNotEquals(-1, $response['id']);
+    }
+
+    public function test_add_instance_success_with_group_new() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        $course     = self::getDataGenerator()->create_course();
+        $cohort     = self::getDataGenerator()->create_cohort();
+        $roleid     = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+        $groupid    = local_ws_enrolcohort_external::COHORT_GROUP_CREATE_NEW;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid, 'groupid' => $groupid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // Validate the response code.
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(201, $response['code']);
+
+        // Validate the response message.
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('addinstance:201'), $response['message']);
+
+        // Validate the response data.
+        $this->assertArrayHasKey('data', $response);
+
+        $responsedatahas = [];
+
+        foreach ($response['data'] as $key => $responsedata) {
+            $this->assertArrayHasKey('object', $responsedata);
+
+            if (!$responsedata['object'] == 'data') {
+                $this->assertArrayHasKey('id', $responsedata);
+            }
+
+            $responsedatahas[$responsedata['object']] = $key;
+        }
+
+        $this->assertArrayHasKey('course', $responsedatahas);
+        $this->assertArrayHasKey('cohort', $responsedatahas);
+        $this->assertArrayHasKey('role', $responsedatahas);
+        $this->assertArrayHasKey('data', $responsedatahas);
+        $this->assertArrayHasKey('group', $responsedatahas);
+        $this->assertGreaterThan(0, $response['data'][$responsedatahas['group']]['id']);
+        $this->assertArrayHasKey('enrol', $responsedatahas);
+        $this->assertEquals(6, count($response['data']));
+
+        // Validate the response id.
+        $this->assertArrayHasKey('id', $response);
+        $this->assertNotEquals(-1, $response['id']);
+    }
+
+    public function test_add_instance_success_with_group_existing() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+        $group  = self::getDataGenerator()->create_group(['courseid' => $course->id]);
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+        $groupid    = $group->id;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid, 'groupid' => $groupid
+            ]);
+        } catch (moodle_exception $exception) {
+            // This should never happen.
+            $this->fail('An unexpected exception was caught ('.get_class($exception).').');
+        }
+
+        // Validate the response code.
+        $this->assertArrayHasKey('code', $response);
+        $this->assertEquals(201, $response['code']);
+
+        // Validate the response message.
+        $this->assertArrayHasKey('message', $response);
+        $this->assertEquals(tools::get_string('addinstance:201'), $response['message']);
+
+        // Validate the response data.
+        $this->assertArrayHasKey('data', $response);
+
+        $responsedatahas = [];
+
+        foreach ($response['data'] as $key => $responsedata) {
+            $this->assertArrayHasKey('object', $responsedata);
+
+            if (!$responsedata['object'] == 'data') {
+                $this->assertArrayHasKey('id', $responsedata);
+            }
+
+            $responsedatahas[$responsedata['object']] = $key;
+        }
+
+        $this->assertArrayHasKey('course', $responsedatahas);
+        $this->assertArrayHasKey('cohort', $responsedatahas);
+        $this->assertArrayHasKey('role', $responsedatahas);
+        $this->assertArrayHasKey('data', $responsedatahas);
+        $this->assertArrayHasKey('group', $responsedatahas);
+        $this->assertEquals($groupid, $response['data'][$responsedatahas['group']]['id']);
+        $this->assertArrayHasKey('enrol', $responsedatahas);
+        $this->assertEquals(6, count($response['data']));
+
+        // Validate the response id.
+        $this->assertArrayHasKey('id', $response);
+        $this->assertNotEquals(-1, $response['id']);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for checking invalid function calls to add_instance().">
+
+    /// <editor-fold desc="Tests for checking call with groupid that doesn't belong to the course.">
+
+    public function test_add_instance_success_with_group_existing_invalid_course() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        $differentcourse = self::getDataGenerator()->create_course();
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+        $group  = self::getDataGenerator()->create_group(['courseid' => $differentcourse->id]);
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+        $groupid    = $group->id;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid, 'groupid' => $groupid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\group_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for add_instance() where role is already synced with role.">
+
+    public function test_add_instance_enrol_instance_already_synced_with_role() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid = $course->id;
+        $cohortid = $cohort->id;
+
+        try {
+            // Simulate an instance where a cohort enrolment instance would be added to a course that already has one.
+            local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $expectedexceptionclass = 'local_ws_enrolcohort\exceptions\cohort_enrol_instance_already_synced_with_role_exception';
+            $this->assertInstanceOf($expectedexceptionclass, $exception);
+            $this->assertEquals('enrolcohortalreadysyncedwithrole', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for add_instance() where status is invalid.">
+
+    public function test_add_instance_invalid_status() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        // Make a course category so we have a context.
+        $coursecategory = self::getDataGenerator()->create_category();
+
+        $course = self::getDataGenerator()->create_course(['category' => $coursecategory->id]);
+        $cohort = self::getDataGenerator()->create_cohort(['contextid' => $coursecategory->get_context()->id]);
+        $roleid = self::getDataGenerator()->create_role();
+        $status = 55;
+
+        $courseid = $course->id;
+        $cohortid = $cohort->id;
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid, 'status' => $status
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\invalid_status_exception', $exception);
+            $this->assertEquals('invalidstatus', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for add_instance() where required params are missing.">
+
+    /**
+     * Test calling the add_instance webservice function missing the required parameters.
+     */
+    public function test_add_instance_missing_required_params() {
+        // The invalid params to test with.
+        $courseid   = 0;
+        $roleid     = 0;
+        $cohortid   = 0;
+
+        $response = null;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance(['courseid' => $courseid]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('invalid_parameter_exception', $exception);
+            $this->assertEquals('invalidparameter', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance(['cohortid' => $cohortid]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('invalid_parameter_exception', $exception);
+            $this->assertEquals('invalidparameter', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance(['roleid' => $roleid]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('invalid_parameter_exception', $exception);
+            $this->assertEquals('invalidparameter', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance(['courseid' => $courseid, 'cohortid' => $cohortid]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('invalid_parameter_exception', $exception);
+            $this->assertEquals('invalidparameter', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance(['courseid' => $courseid, 'roleid' => $roleid]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('invalid_parameter_exception', $exception);
+            $this->assertEquals('invalidparameter', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance(['cohortid' => $cohortid, 'roleid' => $roleid]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('invalid_parameter_exception', $exception);
+            $this->assertEquals('invalidparameter', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for add_instance() where something is not found.">
+
+    public function test_add_instance_course_not_found() {
+        $courseid = $cohortid = $roleid = 0;
+
+        $response = null;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\course_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_add_instance_cohort_not_found() {
+        $this->resetAfterTest();
+
+        $response = null;
+
+        $course = self::getDataGenerator()->create_course();
+
+        $courseid   = $course->id;
+        $cohortid   = 0;
+        $roleid     = 0;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\cohort_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_add_instance_role_not_found() {
+        $this->resetAfterTest();
+
+        $response = null;
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+        $roleid     = 0;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\role_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_add_instance_group_not_found() {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+        $role   = $DB->get_record('role', ['id' => $roleid]);
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid   = $course->id;
+        $cohortid   = $cohort->id;
+        $roleid     = $role->id;
+        $groupid    = 999;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid, 'groupid' => $groupid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\group_not_found_exception', $exception);
+            $this->assertEquals('objectnotfound', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for add_instance() to a site course.">
+
+    public function test_add_instance_site_course() {
+        global $SITE;
+
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $cohort = self::getDataGenerator()->create_cohort();
+        $roleid = self::getDataGenerator()->create_role();
+
+        $courseid = $SITE->id;
+        $cohortid = $cohort->id;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\invalid_course_exception', $exception);
+            $this->assertEquals('invalidcourse', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// <editor-fold desc="Tests for add_instance() for a cohort and role not available at context.">
+
+    public function test_add_instance_cohort_unavailable() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        // Make a course category so we have a context.
+        $coursecategory = self::getDataGenerator()->create_category();
+
+        $course = self::getDataGenerator()->create_course();
+        $cohort = self::getDataGenerator()->create_cohort(['contextid' => $coursecategory->get_context()->id]);
+        $roleid = self::getDataGenerator()->create_role();
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid = $course->id;
+        $cohortid = $cohort->id;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\cohort_not_available_at_context_exception', $exception);
+            $this->assertEquals('unavailableatcontext', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    public function test_add_instance_role_unassignable() {
+        $this->resetAfterTest(true);
+
+        $response = null;
+
+        $this->setAdminUser();
+
+        // Make a course category so we have a context.
+        $coursecategory = self::getDataGenerator()->create_category();
+
+        $course = self::getDataGenerator()->create_course(['category' => $coursecategory->id]);
+        $cohort = self::getDataGenerator()->create_cohort(['contextid' => $coursecategory->get_context()->id]);
+        $roleid = self::getDataGenerator()->create_role(['archetype' => 'frontpage']);
+
+        // Ensure lots of cohorts exist to test the cohort_get_available_cohorts limit is working.
+        self::create_cohorts();
+
+        $courseid = $course->id;
+        $cohortid = $cohort->id;
+
+        try {
+            $response = local_ws_enrolcohort_external::add_instance([
+                'courseid' => $courseid, 'cohortid' => $cohortid, 'roleid' => $roleid
+            ]);
+        } catch (moodle_exception $exception) {
+            $this->assertInstanceOf('local_ws_enrolcohort\exceptions\role_not_assignable_at_context_exception', $exception);
+            $this->assertEquals('unavailableatcontext', $exception->errorcode);
+        }
+
+        $this->assertNull($response);
+    }
+
+    /// </editor-fold>
+
+    /// </editor-fold>
+
+    /// </editor-fold>
+}

--- a/local/ws_enrolcohort/version.php
+++ b/local/ws_enrolcohort/version.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version file for local_ws_enrolcohort.
+ *
+ * @package     local_ws_enrolcohort
+ * @author      Donald Barrett <donald.barrett@learningworks.co.nz>
+ * @copyright   2018 onwards, LearningWorks ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// No direct access.
+defined('MOODLE_INTERNAL') || die();
+
+// This plugin requires Moodle 3.3.
+$plugin->requires = 2017051500;
+
+// Plugin details.
+$plugin->component  = 'local_ws_enrolcohort';
+$plugin->version    = 2022062800;   // Plugin updated June 2022.
+$plugin->release    = 'v3.3.4';
+
+// Plugin status details.
+$plugin->maturity = MATURITY_STABLE;   // ALPHA, BETA, RC, STABLE.


### PR DESCRIPTION
This plugin allows us to enroll cohorts into course.  This is connected to a [pull request](https://github.com/RT-coding-team/cbadmin/pull/34) on cbadmin and a [pull request](https://github.com/RT-coding-team/connectbox-manage/pull/16) on connectbox-manage.  In order to enable all the features in all three of these requests, we need make some changes with our Ansible build.

- We need to Enable cohort sync: **Site administration > Plugins > Enrolments > Manage enrol plugins**
- We need to add these functions Connectbox API external services. **Site administration > Plugins > Web services > External services**
     - core_cohort_create_cohorts
     - core_cohort_delete_cohort_members
     - core_cohort_get_cohorts
     - core_cohort_get_cohort_members
     - core_cohort_update_cohorts
     - core_cohort_delete_cohorts
     - core_cohort_add_cohort_members
     - local_ws_enrolcohort_add_instance
     - local_ws_enrolcohort_delete_instance
     - local_ws_enrolcohort_get_instances

Note: in order for the 'Cohort sync' option to show up here, at least one Cohort must exist and be available at either the site level or the category level in the category the course is in. If there are no Cohorts available, then this option will not appear in the pull down list. 

For more about Cohort Sync check out [this doc](https://docs.moodle.org/37/en/Cohort_sync#Enrolling_a_cohort_in_a_course).
