### PR TITLE
Course Testing Data Sync

### DIFF
--- a/_docs/quiz-reporting-research.md
+++ b/_docs/quiz-reporting-research.md
@@ -1,0 +1,79 @@
+# Quiz Reporting
+
+Detail research on how the stats are generated for Moodle's Quiz mod.  The form does a GET request and reloads the page.
+
+- [Question Engine Details](https://docs.moodle.org/dev/Overview_of_the_Moodle_question_engine#Detailed_data_about_an_attempt).
+
+## URL Parameters
+
+The Overview and Response reports use the following parameters when exporting data:
+
+| Parameter | Description |
+| --------- | ----------- |
+| download | The file type to download. **options:** json, csv, excel, html, ods, pdf. |
+| id | The quiz id. |
+| mode | The report mode. **options:** overview (General Overview), responses (Students Answers), statistics (Overall Stats). |
+| attempts | The type of attempts to display. **options:** enrolled_with (enrolled users who have attempted the quiz), enrolled_without (enrolled users who have not attempted the quiz), enrolled_any (enrolled users who have, or have not, attempted the quiz), all_with (all users who have attempted the quiz). |
+| states | Specific states of the quiz to display. Add a dash between each state to include. **options:** overdue, finished, abandoned, inprogress. |
+| onlygraded | Show at most one finished attempt per user. |
+| sesskey | The session key of the logged in user. **required** |
+
+## Grades (Overview) Report
+
+Get the overview report with grades per question.
+
+### URL
+http://learn.dev-staging.thewellcloud.cloud/mod/quiz/report.php?sesskey=2P4X1p01ia&download=json&id=543&mode=overview&attempts=enrolled_with&onlygraded=&onlyregraded=&slotmarks=1
+
+#### Custom Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| slotmarks | Do you want to see the grades for each question? (0-1) |
+
+
+## Reponse Report
+
+Get information on how a user responded to a quiz.
+
+### URL
+
+http://learn.dev-staging.thewellcloud.cloud/mod/quiz/report.php?sesskey=JFe9BERcrV&download=json&id=543&mode=responses&attempts=enrolled_with&onlygraded=&qtext=1&resp=1&right=1 
+
+#### Custom Parameters
+
+| Parameter | Description |
+| --------- | ----------- |
+| qtext | Do you want to display the question text? (0 or 1) |
+| resp | Do you want to display their response? (0 or 1) |
+| right | Do you want to display the right answer? (0 or 1) |
+
+
+## Code Breakdown
+
+When requesting downloading content:
+
+- calls mod/quiz/report.php.
+- Looks for a class called **report/$mode/report.php**, and then it includes and sets up the class.
+- It calls **display()** on that class.
+    - Somewhere in **display()** they are triggering the download.
+- Outputs the view.
+
+## Various Notes
+
+- login a user
+
+```
+// login the user
+$user = authenticate_user_login('admin', $password);
+if (!$user) {
+    echo "We are unable to login.  Please check the credentials for the admin user.\r\n";
+    exit;
+}
+complete_user_login($user);
+$sessionKey = $_SESSION['USER']->sesskey;
+if (!$sessionKey) {
+    echo "We did not receive a session key.\r\n";
+    exit;
+}
+```

--- a/_docs/quiz-reporting-research.md
+++ b/_docs/quiz-reporting-research.md
@@ -3,6 +3,16 @@
 Detail research on how the stats are generated for Moodle's Quiz mod.  The form does a GET request and reloads the page.
 
 - [Question Engine Details](https://docs.moodle.org/dev/Overview_of_the_Moodle_question_engine#Detailed_data_about_an_attempt).
+- [Question Database Structure](https://docs.moodle.org/dev/Question_database_structure).
+- [Quiz Database Structure](https://docs.moodle.org/dev/Quiz_database_structure).
+
+I was able to find the Query by following these steps:
+
+1. Open the report.php where the download is triggered.
+2. Locate the function call `$table->out`.
+3. Right before it, type `print_r($table->sql);` and refresh the page.
+
+This is how you find the parts of the query that is being fired.
 
 ## URL Parameters
 

--- a/local/scripts/classes/CurlUtility.php
+++ b/local/scripts/classes/CurlUtility.php
@@ -1,0 +1,214 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A utility for making cURL requests. This is a modified version of the file in
+ * ChatAttachments plugin.
+ */
+class CurlUtility
+{
+    /**
+     * The status code of the request
+     *
+     * @var integer
+     * @access public
+     */
+    public $responseCode = 0;
+
+    /**
+     * The last URL visited by cURL
+     *
+     * @var string
+     * @access public
+     **/
+    public $lastVisitedURL = '';
+
+    /**
+     * The main url to request
+     *
+     * @var integer
+     * @access public
+     */
+    private $url = '';
+
+    /**
+     * The authorization bearer token (if required)
+     *
+     * @var string
+     */
+    private $token = '';
+
+    /**
+     * Set up the class
+     *
+     * @param string    $url    The URL
+     * @param string    $token  The token to access the API
+     *
+     * @throws InvalidArgumentException     If the URL is not set
+
+     */
+    public function __construct($url, $token = '') {
+        if ($url === '') {
+            throw new InvalidArgumentException('You must provide a valid URL.');
+        }
+        if (substr($url, -1) !== '/') {
+            /**
+             * Add the trailing slash if missing
+             */
+            $this->url = $url . '/';
+        } else {
+            $this->url = $url;
+        }
+        $this->token = $token;
+    }
+
+    /**
+     * Make a cURL Request
+     *
+     * @param string        $path       the path to request
+     * @param string        $method     the method to use POST or GET
+     * @param array|string  $data       The data to send (string or array)
+     * @param string        $filepath   A path to a file to send.
+     * @param string        $isJson     Is the data JSON? (Send data as a string)
+     * @return string
+     * @access public
+     * @throws  InvalidArgumentException    If you supply a filepath, but send as a GET
+     * @throws  InvalidArgumentException    If you supply a filepath, but send data as a string
+     * @throws  InvalidArgumentException    If you supply a filepath, but the file does not exist
+     */
+    public function makeRequest($path, $method, $data, $filepath = null, $isJson = false)
+    {
+        $url = $this->url . '' . ltrim($path, '/');
+        $method = strtoupper($method);
+        $headers = [];
+
+        if ($isJson) {
+            $headers[] = 'Content-Type: application/json';
+        }
+        if (($filepath) && ($method !== 'POST')) {
+            throw new InvalidArgumentException('If you supply a filepath, the method must be POST.');
+        }
+
+        if (($filepath) && (!is_array($data))) {
+            throw new InvalidArgumentException('If you supply a filepath, the data must be an array.');
+        }
+
+        if (($filepath) && (!file_exists($filepath))) {
+            throw new InvalidArgumentException('If you supply a filepath, the file must exist.');
+        }
+
+        if ($filepath) {
+            $mimeType = mime_content_type($filepath);
+            $data['file'] = new CURLFile($filepath, $mimeType, basename($filepath));
+        }
+
+        /**
+         * open connection
+         */
+        $ch = curl_init();
+        $payload = $data;
+        if ($method == 'GET') {
+            if (is_array($data)) {
+                $payload = $this->urlify($data);
+            }
+            $url = $url . '?' . $payload;
+        }
+        /**
+         * Setup cURL, we start by spoofing the user agent since it is from code:
+         * http://davidwalsh.name/set-user-agent-php-curl-spoof
+         */
+        curl_setopt(
+            $ch,
+            CURLOPT_USERAGENT,
+            'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13'
+        );
+
+		// Add the authorization headers
+		$headers[] = 'Authorization: Bearer ' . $this->token;
+
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        /**
+         * Follow all redirections
+         **/
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+        if ($method == 'POST') {
+            curl_setopt($ch, CURLOPT_POST, 1);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        }
+        /**
+         * execute request
+         */
+        $result = curl_exec($ch);// or die(curl_error($ch));
+        $this->responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $this->lastVisitedURL = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+        /**
+         * close connection
+         */
+        curl_close($ch);
+        return $result;
+    }
+
+    /**
+     * Download a file locally
+     *
+     * @param  string $sourcePath  The path of the file on the url
+     * @param  string $destination The destination of the file
+     * @return boolean             Successfully downloaded?
+     *
+     * @link https://stackoverflow.com/a/6409531/4638563
+     */
+    public function downloadFile($sourcePath, $destination)
+    {
+        $url = $this->url . '' . ltrim($sourcePath, '/');
+		$headers = [];
+		$headers[] = 'Authorization: Bearer ' . $this->boxId . $this->token;		
+        $write = fopen($destination, 'w+b');
+        //Here is the file we are downloading, replace spaces with %20
+        $ch = curl_init(str_replace(' ', '%20', $url));
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 50);
+        // write curl response to file
+        curl_setopt($ch, CURLOPT_FILE, $write);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        // get curl response
+        curl_exec($ch);
+        curl_close($ch);
+        fclose($write);
+
+        return (file_exists($destination));
+    }
+
+    /**
+     * Takes an array of fields and makes a string from them for passing in cURL
+     *
+     * @param array $fields the fields to urlify
+     * @return string
+     * @access public
+     */
+    public function urlify($fields)
+    {
+        $fieldsString = '';
+        foreach ($fields as $key => $value) {
+            $fieldsString .= $key.'='.$value.'&';
+        }
+        return rtrim($fieldsString, '&');
+    }
+
+}

--- a/local/scripts/classes/CurlUtility.php
+++ b/local/scripts/classes/CurlUtility.php
@@ -137,7 +137,7 @@ class CurlUtility
         );
 
 		// Add the authorization headers
-        if ($this->token) {
+        if (!empty($this->token)) {
             $headers[] = 'Authorization: Bearer ' . $this->token;
         }
 
@@ -180,7 +180,7 @@ class CurlUtility
     {
         $url = $this->url . '' . ltrim($sourcePath, '/');
 		$headers = [];
-        if ($this->token) {
+        if (!empty($this->token)) {
             $headers[] = 'Authorization: Bearer ' . $this->token;
         }		
         $write = fopen($destination, 'w+b');

--- a/local/scripts/classes/CurlUtility.php
+++ b/local/scripts/classes/CurlUtility.php
@@ -137,7 +137,9 @@ class CurlUtility
         );
 
 		// Add the authorization headers
-		$headers[] = 'Authorization: Bearer ' . $this->token;
+        if ($this->token) {
+            $headers[] = 'Authorization: Bearer ' . $this->token;
+        }
 
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
@@ -178,7 +180,9 @@ class CurlUtility
     {
         $url = $this->url . '' . ltrim($sourcePath, '/');
 		$headers = [];
-		$headers[] = 'Authorization: Bearer ' . $this->boxId . $this->token;		
+        if ($this->token) {
+            $headers[] = 'Authorization: Bearer ' . $this->token;
+        }		
         $write = fopen($destination, 'w+b');
         //Here is the file we are downloading, replace spaces with %20
         $ch = curl_init(str_replace(' ', '%20', $url));

--- a/local/scripts/classes/serializers/AssignmentSerializer.php
+++ b/local/scripts/classes/serializers/AssignmentSerializer.php
@@ -81,6 +81,10 @@ class AssignmentSerializer
      */
     public function results($courseId, $courseModuleId)
     {
+        if (!$this->assignment) {
+            return [];
+        }
+
         $results = [];
         $context = context_module::instance($courseModuleId);
         $users = get_enrolled_users($context, "mod/assign:submit", 0, 'u.id');

--- a/local/scripts/classes/serializers/AssignmentSerializer.php
+++ b/local/scripts/classes/serializers/AssignmentSerializer.php
@@ -71,6 +71,14 @@ class AssignmentSerializer
         ];
     }
 
+    /**
+     * Get the results from the assignment.
+     * 
+     * @param integer $courseId         The id of the course
+     * @param integer $courseModuleId   The id for the course module
+     * 
+     * @return array                    The results
+     */
     public function results($courseId, $courseModuleId)
     {
         $results = [];

--- a/local/scripts/classes/serializers/AssignmentSerializer.php
+++ b/local/scripts/classes/serializers/AssignmentSerializer.php
@@ -1,0 +1,104 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'dmllib.php');
+
+/**
+ * Retrieves assignment data from the database and returns as a PHP array.
+ */
+class AssignmentSerializer
+{
+    /**
+     * Our assignment that is being serialized
+     */
+    protected $assignment;
+    /**
+     * An instance of Moodle's database
+     */
+    protected $db = null;
+    /**
+     * The query to get the results. IN is dynamically added.
+     */
+    protected $query = "SELECT u.id, u.firstname, u.lastname, u.middlename , u.id as userid, s.status as status, " .
+    "s.id as submissionid, s.timecreated, s.timemodified, s.attemptnumber as attemptnumber, g.id as gradeid, g.grade as grade " .
+    "FROM {user} u LEFT JOIN {assign_submission} s ON u.id = s.userid AND s.assignment = :assign1 AND s.latest = 1 LEFT JOIN " .
+    "{assign_grades} g ON g.assignment = :assign2 AND u.id = g.userid AND (g.attemptnumber = s.attemptnumber " .
+    "OR s.attemptnumber IS NULL) WHERE u.id IN";
+
+    /**
+     * Build the class
+     * 
+     * @param integer   $id                 The quiz id
+     * @param object    $database           The Moodle database object
+     */
+    public function __construct($id, $database)
+    {
+        $this->db = $database;
+        $this->assignment = $this->db->get_record('assign', ['id' => $id]);
+    }
+
+    /**
+     * Get the details about the assignment
+     * 
+     * @return array    The details about the assignment|empty if no assignment exists
+     */
+    public function details()
+    {
+        if (!$this->assignment) {
+            return [];
+        }
+
+        return [
+            'id'            =>  $this->assignment->id,
+            'type'          =>  'assignment',
+            'name'          =>  $this->assignment->name,
+            'intro'         =>  strip_tags($this->assignment->intro),
+            'max_grade'     =>  $this->assignment->grade,
+            'due_on'        =>  $this->assignment->duedate,
+            'modified_on'   =>  $this->assignment->timemodified,
+        ];
+    }
+
+    public function results($courseId, $courseModuleId)
+    {
+        $results = [];
+        $context = context_module::instance($courseModuleId);
+        $users = get_enrolled_users($context, "mod/assign:submit", 0, 'u.id');
+        $params = [
+            'assign1'   =>  $this->assignment->id,
+            'assign2'   =>  $this->assignment->id 
+        ];
+        $labels = [];
+        foreach ($users as $user) {
+            $labels[] = ':user' . $user->id;
+            $params['user' . $user->id] = $user->id;
+        }
+        $submissions = $this->db->get_records_sql($this->query . ' (' . implode(',', $labels) .')', $params);
+        foreach ($submissions as $submission) {
+            $results[] = [
+                'submission_id'     =>  $submission->submissionid,
+                'user_id'           =>  $submission->userid,
+                'firstname'         =>  $submission->firstname,
+                'lastname'          =>  $submission->lastname,
+                'grade'             =>  $submission->grade,
+                'state'             =>  $submission->status,
+                'total_attempts'    =>  $submission->attemptnumber,
+                'created_on'        =>  $submission->timecreated,
+                'modified_on'       =>  $submission->timemodified
+            ];
+        }
+        return $results;
+    }
+}

--- a/local/scripts/classes/serializers/FeedbackSerializer.php
+++ b/local/scripts/classes/serializers/FeedbackSerializer.php
@@ -1,0 +1,149 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Retrieves feedback data from the database and returns as a PHP array.
+ */
+class FeedbackSerializer
+{
+    /**
+     * An instance of Moodle's database
+     */
+    protected $db = null;
+
+    /**
+     * The feedback being serialized
+     */
+    protected $feedback;
+
+    /**
+     * The query for getting results
+     */
+    protected $query = "SELECT DISTINCT '' || fv.completed || '-' || fv.item as uniqueid, fc.id as fcid, u.id as userid, u.firstname, u.lastname, " .
+    "fc.timemodified, fi.id as fiid, fi.name as question, fi.label, fi.presentation, fi.typ as questiontype, " .
+    "fv.value as answer FROM mdl_feedback_value AS fv INNER JOIN mdl_feedback_completed AS fc ON fc.id = fv.completed " .
+    "INNER JOIN mdl_user as u ON fc.userid = u.id INNER JOIN mdl_feedback_item" .
+    " as fi ON fv.item = fi.id WHERE fc.feedback = :feedbackid AND fi.typ NOT IN ('info', 'label', 'pagebreak', 'captcha')";
+
+    /**
+     * Build the class
+     * 
+     * @param integer   $id                 The feedback id
+     * @param object    $database           The Moodle database object
+     */
+    public function __construct($id, $database)
+    {
+        $this->db = $database;
+        $this->feedback = $this->db->get_record('feedback', ['id' => $id]);
+    }
+
+    /**
+     * Get the details about the feedback
+     * 
+     * @return array    The details about the feedback|empty if no feedback exists
+     */
+    public function details()
+    {
+        if (!$this->feedback) {
+            return [];
+        }
+
+        return [
+            'id'            =>  $this->feedback->id,
+            'anonymous'     =>  ($this->feedback->anonymous == 1),
+            'type'          =>  'feedback',
+            'name'          =>  $this->feedback->name,
+            'intro'         =>  strip_tags($this->feedback->intro),
+            'modified_on'   =>  $this->feedback->timemodified,
+        ];
+    }
+
+    /**
+     * Get the results of the feedback request
+     * 
+     * @return array    The results
+     */
+    public function results()
+    {
+        if (!$this->feedback) {
+            return [];
+        }
+
+        $submissions = $this->db->get_records_sql(
+            $this->query,
+            ['feedbackid'  =>  $this->feedback->id]
+        );
+        // We will hold the data in this array then push into the result array. We need this array keyed to the user id.
+        $data = [];
+        foreach ($submissions as $submission) {
+            if (!array_key_exists($submission->userid, $data)) {
+                $userid = ($this->feedback->anonymous == 1) ? -1 : $submission->userid;
+                $firstname = ($this->feedback->anonymous == 1) ? 'Anonymous' : $submission->firstname;
+                $lastname = ($this->feedback->anonymous == 1) ? '' : $submission->lastname;
+                $data[$submission->userid] = [
+                    'user_id'           =>  $userid,
+                    'firstname'         =>  $firstname,
+                    'lastname'          =>  $lastname,
+                    'answers'           =>  [],
+                    'modified_on'       =>  $submission->timemodified
+                ];
+            }
+            $selected = '';
+            $scale = null;
+            switch($submission->questiontype) {
+                case 'multichoicerated':
+                    // Answer is in presentation and looks like this: r>>>>>0####Democracy|1####Anarchy|2####Oligarchy|3####Dictatorship|4####Royalty by Decree
+                    $cleaned = str_replace('####', ' - ', str_replace(["\r\n", "\r", "\n"], "", substr($submission->presentation, 5)));
+                    $choices = explode('|', $cleaned);
+                    $answerIndex = intval($submission->answer) - 1;
+                    $selected = (array_key_exists($answerIndex, $choices)) ? $choices[$answerIndex] : '';
+                    break;
+                case 'multichoice':
+                    // Answer is in presentation and looks like this: r>>>>>King Arthur\r|Merlin\r|Sir Gallahad\r|Myself
+                    $cleaned = str_replace(["\r\n", "\r", "\n"], "", substr($submission->presentation, 5));
+                    $choices = explode('|', $cleaned);
+                    $answerIndex = intval($submission->answer) - 1;
+                    $selected = (array_key_exists($answerIndex, $choices)) ? $choices[$answerIndex] : '';
+                    break;
+                case 'numeric':
+                    $scalePieces = explode('|', $submission->presentation);
+                    $scale = [
+                        'min'   =>  $scalePieces[0],
+                        'max'   =>  $scalePieces[1]
+                    ];
+                default:
+                    $selected = $submission->answer;
+                    break;
+            }
+            $answer = [
+                'feedback_item' =>  [
+                    'id'        =>  $submission->fiid,
+                    'label'     =>  $submission->label,
+                    'question'  =>  $submission->question
+                ],
+                'answer'    =>  $selected,
+                'scale'     =>  $scale
+            ];
+            $data[$submission->userid]['answers'][] = $answer;
+        }
+        $results = [];
+        foreach ($data as $item) {
+            $results[] = $item;
+        }
+
+        return $results;
+    }
+}

--- a/local/scripts/classes/serializers/QuizSerializer.php
+++ b/local/scripts/classes/serializers/QuizSerializer.php
@@ -18,7 +18,7 @@ require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_S
 /**
  * Retrieves quiz data from the database and returns as a PHP array.
  */
-class QuizSerializer 
+class QuizSerializer
 {
     /**
      * An instance of Moodle's database
@@ -28,18 +28,17 @@ class QuizSerializer
      * The query to get the results
      */
     protected $query = "SELECT DISTINCT '' || u.id || '#' || COALESCE(quiza.attempt, 0) AS uniqueid, " . 
-    "(CASE WHEN (quiza.state = 'finished' AND NOT EXISTS ( SELECT 1 FROM {quiz_attempts} qa2 " .
-    "WHERE qa2.quiz = quiza.quiz AND qa2.userid = quiza.userid AND qa2.state = 'finished' AND " .
-    "( COALESCE(qa2.sumgrades, 0) > COALESCE(quiza.sumgrades, 0) OR (COALESCE(qa2.sumgrades, 0) = COALESCE(quiza.sumgrades, 0) " .
-    "AND qa2.attempt < quiza.attempt) ))) THEN 1 ELSE 0 END) AS gradedattempt, quiza.uniqueid AS usageid, quiza.id AS attempt, " .
-    "u.id AS userid, u.idnumber, u.firstnamephonetic,u.lastnamephonetic,u.middlename,u.alternatename,u.firstname,u.lastname, " .
-    "u.institution, u.department, u.email, quiza.state, quiza.sumgrades, quiza.timefinish, quiza.timestart, CASE WHEN quiza.timefinish = 0 " .
-    "THEN null WHEN quiza.timefinish > quiza.timestart THEN quiza.timefinish - quiza.timestart ELSE 0 END AS duration, " .
-    "COALESCE(( SELECT MAX(qqr.regraded) FROM {quiz_overview_regrades} qqr WHERE qqr.questionusageid = quiza.uniqueid ), -1) " .
-    "AS regraded FROM {user} u LEFT JOIN {quiz_attempts} quiza ON quiza.userid = u.id AND quiza.quiz = :quizid JOIN {user_enrolments} " .
-    "ej1_ue ON ej1_ue.userid = u.id JOIN {enrol} ej1_e ON (ej1_e.id = ej1_ue.enrolid AND ej1_e.courseid = :courseid) JOIN " .
-    "(SELECT DISTINCT userid FROM {role_assignments} WHERE contextid IN (1,565,717,738) AND roleid IN (5) ) ra ON ra.userid = u.id " .
-    "WHERE quiza.preview = 0 AND quiza.id IS NOT NULL AND u.deleted = 0 AND u.id <> 1 AND u.deleted = 0";
+    "(CASE WHEN (quiza.state = 'finished' AND NOT EXISTS ( SELECT 1 FROM {quiz_attempts} qa2 WHERE qa2.quiz = quiza.quiz " .
+    "AND qa2.userid = quiza.userid AND qa2.state = 'finished' AND ( COALESCE(qa2.sumgrades, 0) > COALESCE(quiza.sumgrades, 0) " .
+    "OR (COALESCE(qa2.sumgrades, 0) = COALESCE(quiza.sumgrades, 0) AND qa2.attempt < quiza.attempt) ))) THEN 1 ELSE 0 END) AS " .
+    "gradedattempt, quiza.uniqueid AS usageid, quiza.id AS attempt, u.id AS userid, u.idnumber, u.firstname, u.lastname, " .
+    "quiza.state, quiza.sumgrades, quiza.timefinish, quiza.timestart, CASE WHEN quiza.timefinish = 0 " .
+    "THEN null WHEN quiza.timefinish > quiza.timestart THEN quiza.timefinish - quiza.timestart ELSE 0 END AS duration " .
+    "FROM {user} u LEFT JOIN {quiz_attempts} quiza ON quiza.userid = u.id AND quiza.quiz = :quizid JOIN {user_enrolments} " .
+    "uenroll ON uenroll.userid = u.id JOIN {enrol} enrol ON (enrol.id = uenroll.enrolid AND enrol.courseid = :courseid) JOIN " .
+    "(SELECT DISTINCT userid FROM {role_assignments} as dra JOIN {context} dcon ON dra.contextid = dcon.id WHERE dcon.contextlevel " .
+    "IN (10,40,50,70) AND dra.roleid IN (5)) ra ON ra.userid = u.id WHERE quiza.preview = 0 AND quiza.id IS NOT NULL AND " .
+    "u.deleted = 0 AND u.id <> 1 AND u.deleted = 0";
 
     /**
      * The quiz being serialized

--- a/local/scripts/classes/serializers/QuizSerializer.php
+++ b/local/scripts/classes/serializers/QuizSerializer.php
@@ -67,6 +67,7 @@ class QuizSerializer
         if (!$this->quiz) {
             return [];
         }
+
         return [
             'id'            =>  $this->quiz->id,
             'type'          =>  'quiz',
@@ -86,6 +87,10 @@ class QuizSerializer
      */
     public function results($courseId)
     {
+        if (!$this->quiz) {
+            return [];
+        }
+
         $results = [];
         $attempts = $this->db->get_records_sql(
             $this->query,

--- a/local/scripts/classes/serializers/QuizSerializer.php
+++ b/local/scripts/classes/serializers/QuizSerializer.php
@@ -94,6 +94,7 @@ class QuizSerializer
         );
         foreach ($attempts as $attempt) {
             $results[] = [
+                'user_id'       =>  $attempt->userid,
                 'firstname'     =>  $attempt->firstname,
                 'lastname'      =>  $attempt->lastname,
                 'duration'      =>  $attempt->duration,

--- a/local/scripts/classes/serializers/QuizSerializer.php
+++ b/local/scripts/classes/serializers/QuizSerializer.php
@@ -1,4 +1,18 @@
 <?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_SEPARATOR . 'mod' . DIRECTORY_SEPARATOR . 'quiz' . DIRECTORY_SEPARATOR . 'locallib.php');
 
 /**

--- a/local/scripts/classes/serializers/QuizSerializer.php
+++ b/local/scripts/classes/serializers/QuizSerializer.php
@@ -1,0 +1,94 @@
+<?php
+require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_SEPARATOR . 'mod' . DIRECTORY_SEPARATOR . 'quiz' . DIRECTORY_SEPARATOR . 'locallib.php');
+
+/**
+ * Retrieves quiz data from the database and returns as a PHP array.
+ */
+class QuizSerializer 
+{
+    /**
+     * An instance of Moodle's database
+     */
+    protected $db = null;
+    /**
+     * The query to get the results
+     */
+    protected $query = "SELECT DISTINCT '' || u.id || '#' || COALESCE(quiza.attempt, 0) AS uniqueid, " . 
+    "(CASE WHEN (quiza.state = 'finished' AND NOT EXISTS ( SELECT 1 FROM {quiz_attempts} qa2 " .
+    "WHERE qa2.quiz = quiza.quiz AND qa2.userid = quiza.userid AND qa2.state = 'finished' AND " .
+    "( COALESCE(qa2.sumgrades, 0) > COALESCE(quiza.sumgrades, 0) OR (COALESCE(qa2.sumgrades, 0) = COALESCE(quiza.sumgrades, 0) " .
+    "AND qa2.attempt < quiza.attempt) ))) THEN 1 ELSE 0 END) AS gradedattempt, quiza.uniqueid AS usageid, quiza.id AS attempt, " .
+    "u.id AS userid, u.idnumber, u.firstnamephonetic,u.lastnamephonetic,u.middlename,u.alternatename,u.firstname,u.lastname, " .
+    "u.institution, u.department, u.email, quiza.state, quiza.sumgrades, quiza.timefinish, quiza.timestart, CASE WHEN quiza.timefinish = 0 " .
+    "THEN null WHEN quiza.timefinish > quiza.timestart THEN quiza.timefinish - quiza.timestart ELSE 0 END AS duration, " .
+    "COALESCE(( SELECT MAX(qqr.regraded) FROM {quiz_overview_regrades} qqr WHERE qqr.questionusageid = quiza.uniqueid ), -1) " .
+    "AS regraded FROM {user} u LEFT JOIN {quiz_attempts} quiza ON quiza.userid = u.id AND quiza.quiz = :quizid JOIN {user_enrolments} " .
+    "ej1_ue ON ej1_ue.userid = u.id JOIN {enrol} ej1_e ON (ej1_e.id = ej1_ue.enrolid AND ej1_e.courseid = :courseid) JOIN " .
+    "(SELECT DISTINCT userid FROM {role_assignments} WHERE contextid IN (1,565,717,738) AND roleid IN (5) ) ra ON ra.userid = u.id " .
+    "WHERE quiza.preview = 0 AND quiza.id IS NOT NULL AND u.deleted = 0 AND u.id <> 1 AND u.deleted = 0";
+
+    /**
+     * The quiz being serialized
+     */
+    protected $quiz;
+
+    /**
+     * Build the class
+     * 
+     * @param integer   $id         The quiz id
+     * @param object    $database   The Moodle database object
+     */
+    public function __construct($id, $database)
+    {
+        $this->db = $database;
+        $this->quiz = $this->db->get_record('quiz', array('id' => $id));
+    }
+
+    /**
+     * Get the details about the quiz
+     * 
+     * @return array an array of details about the quiz
+     */
+    public function details()
+    {
+        if (!$this->quiz) {
+            return [];
+        }
+        return [
+            'id'            =>  $this->quiz->id,
+            'type'          =>  'quiz',
+            'name'          =>  $this->quiz->name,
+            'intro'         =>  strip_tags($this->quiz->intro),
+            'max_grade'     =>  $this->quiz->grade,
+            'created_on'    =>  $this->quiz->timecreated,
+            'modified_on'   =>  $this->quiz->timemodified,
+        ];
+    }
+    /**
+     * Get the results of the quiz
+     * 
+     * @param integer $courseId The id of the course
+     * 
+     * @return array            An array of results
+     */
+    public function results($courseId)
+    {
+        $results = [];
+        $attempts = $this->db->get_records_sql(
+            $this->query,
+            ['quizid'  =>  $this->quiz->id, 'courseid' => $courseId]
+        );
+        foreach ($attempts as $attempt) {
+            $results[] = [
+                'firstname'     =>  $attempt->firstname,
+                'lastname'      =>  $attempt->lastname,
+                'duration'      =>  $attempt->duration,
+                'grade'         =>  quiz_rescale_grade($attempt->sumgrades, $this->quiz),
+                'state'         =>  quiz_attempt_state_name($attempt->state),
+                'started_on'    =>  $attempt->timestart,
+                'finished_on'   =>  $attempt->timefinish,
+            ];
+        }
+        return $results;
+    }
+}

--- a/local/scripts/classes/serializers/SurveySerializer.php
+++ b/local/scripts/classes/serializers/SurveySerializer.php
@@ -1,0 +1,190 @@
+<?php
+use BirknerAlex\XMPPHP\Exception;
+require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'moodlelib.php');
+require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'accesslib.php');
+
+/**
+ * Retrieves survey data from the database and returns as a PHP array that can be serialized.
+ */
+class SurveySerializer
+{
+    /**
+     * An instance of Moodle's database
+     */
+    protected $db = null;
+
+    /**
+     * The survey being serialized
+     */
+    protected $survey;
+
+    /**
+     * Build the class
+     * 
+     * @param integer   $id         The survey id
+     * @param object    $database   The Moodle database object
+     */
+    public function __construct($id, $database)
+    {
+        $this->db = $database;
+        $this->survey = $this->db->get_record('survey', ['id'   =>  $id]);
+    }
+
+    /**
+     * Get the details about the survey
+     * 
+     * @return array    The details about the survey|empty if no survey exists
+     */
+    public function details()
+    {
+        if (!$this->survey) {
+            return [];
+        }
+
+        return [
+            'id'            =>  $this->survey->id,
+            'type'          =>  'survey',
+            'name'          =>  $this->survey->name,
+            'intro'         =>  strip_tags($this->survey->intro),
+            'created_on'    =>  $this->survey->timecreated,
+            'modified_on'   =>  $this->survey->timemodified,
+            'results'       =>  []
+        ];
+    }
+
+    /**
+     * Get the results from the survey.  Adapted from code in mod/survey/download.php.
+     * 
+     */
+    public function results($courseId, $courseModuleId)
+    {
+        $results = [];
+        // Get and collate all answers in a single array
+        $answers = $this->db->get_records('survey_answers', ['survey'   =>  $this->survey->id], 'time ASC');
+        if (!$answers) {
+            return [];
+        }
+        $module = get_coursemodule_from_id('survey', $courseModuleId);
+        if (!$module) {
+            throw new Exception('The course module is missing for survey ' . $this->survey->id . '!');
+        }
+        $context = context_module::instance($module->id);
+        $users = get_users_by_capability($context, 'mod/survey:participate', '', '', '', '', '', null, false);
+        /**
+         * The questions is a comma seperated array of ids in the correct order.
+         * Get a correct order of the questions. We will reset questions later, so
+         * do not use it as the ordered questions.
+         */
+        $order = explode(',', $this->survey->questions);
+        $questions = $this->db->get_records_list('survey_questions', 'id', $order);
+        $orderedQuestions = [];
+        // Not sure why they use this?
+        $isVirtualScale = false;
+        foreach ($order as $id) {
+            $orderedQuestions[$id] = $questions[$id];
+            if (!$isVirtualScale && $questions[$id]->type < 0) {
+                $isVirtualScale = true;
+            }
+        }
+        // Will hold the questions with nested questions in order
+        $nestedOrder = [];
+        //Not sure about this code?
+        foreach ($orderedQuestions as $id => $question) {
+            if (!empty($question->multi)) {
+                $multiIds = explode(',', $questions[$id]->multi);
+                foreach ($multiIds as $subId) {
+                    if (!empty($orderedQuestions[$subId]->type)) {
+                        $orderedQuestions[$subId]->type = $questions[$id]->type;
+                    }
+                }
+            } else {
+                $multiIds = [$id];
+            }
+            if ($isVirtualScale && $questions[$id]->type < 0) {
+                $nestedOrder[$id] = $multiIds; 
+            } else if (!$isVirtualScale && $question->type >= 0) {
+                $nestedOrder[$id] = $multiIds;
+            } else {
+                $nestedOrder[$id] = [];
+            }
+        }
+        /**
+         * We need to collect the questions for nested questions
+         */
+        $reverseNestedOrder = [];
+        foreach ($nestedOrder as $questionId => $subIds) {
+            foreach ($subIds as $subId) {
+                $reverseNestedOrder[$subId] = $questionId;
+            }
+        }
+        $allQuestions = array_merge(
+            $questions,
+            $this->db->get_records_list('survey_questions', 'id', array_keys($reverseNestedOrder))
+        );
+        // array_merge() messes up the keys so reinstate them
+        $questions = [];
+        foreach ($allQuestions as $question) {
+            $questions[$question->id] = $question;
+            // Let us also get the text of the question
+            $questions[$question->id]->text = get_string($questions[$question->id]->text, 'survey');
+        }
+        /**
+         * Collect answers and the user information into an array
+         */
+        $data = [];
+        foreach ($answers as $answer) {
+            if (isset($users[$answer->userid])) {
+                $questionId = $answer->question;
+                if (!array_key_exists($answer->userid, $data)) {
+                    $data[$answer->userid] = [
+                        'time'  =>  $answer->time
+                    ];
+                }
+                $data[$answer->userid][$questionId]['answer1'] = $answer->answer1;
+                $data[$answer->userid][$questionId]['answer2'] = $answer->answer2;
+            }
+        }
+        foreach ($data as $userId => $rest) {
+            $user = $this->db->get_record('user', ['id' =>  $userId]);
+            if (!$user) {
+                continue;
+            }
+            $notes = $this->db->get_record('survey_analysis', ['survey' =>  $this->survey->id, 'userid' =>  $userId]);
+            if (!$notes) {
+                $notes = 'No notes made.';
+            }
+            $result = [
+                'user_id'       =>  $user->id,
+                'firstname'     =>  $user->firstname,
+                'lastname'      =>  $user->lastname,
+                'notes'         =>  $notes,
+                'answers'       =>  [],
+                'started_on'    =>  $data[$userId]['time']
+            ];
+            foreach ($nestedOrder as $nestedQuestions) {
+                foreach ($nestedQuestions as $questionId) {
+                    $answer = [];
+                    $question = $questions[$questionId];
+                    $answer['question'] = [
+                        'id'    =>  $question->id,
+                        'text'  =>  $question->text,
+                    ];
+                    $answer['answer'] = '';
+                    if ($question->type == '2' || $question->type == '3') {
+                        $answer['question'] .= ' (preferred)';
+                    }
+                    if (in_array($question->type, ['0', '1', '3', '-1']) && array_key_exists($questionId, $data[$userId])) {
+                        $answer['answer'] = $data[$userId][$questionId]['answer1'];
+                    }
+                    // Not sure why 3 is in both if checks.
+                    if (in_array($question->type, ['2', '3']) && array_key_exists($questionId, $data[$userId])) {
+                        $answer['answer'] = $data[$userId][$questionId]['answer2'];
+                    }
+                    $result['answers'][] = $answer;
+                }
+            }
+            $results[] = $result;
+        }
+        return $results;
+    }
+}

--- a/local/scripts/classes/serializers/SurveySerializer.php
+++ b/local/scripts/classes/serializers/SurveySerializer.php
@@ -76,11 +76,7 @@ class SurveySerializer
         if (!$answers) {
             return [];
         }
-        $module = get_coursemodule_from_id('survey', $courseModuleId);
-        if (!$module) {
-            throw new Exception('The course module is missing for survey ' . $this->survey->id . '!');
-        }
-        $context = context_module::instance($module->id);
+        $context = context_module::instance($courseModuleId);
         $users = get_users_by_capability($context, 'mod/survey:participate', '', '', '', '', '', null, false);
         /**
          * The questions is a comma seperated array of ids in the correct order.

--- a/local/scripts/classes/serializers/SurveySerializer.php
+++ b/local/scripts/classes/serializers/SurveySerializer.php
@@ -60,8 +60,7 @@ class SurveySerializer
             'name'          =>  $this->survey->name,
             'intro'         =>  strip_tags($this->survey->intro),
             'created_on'    =>  $this->survey->timecreated,
-            'modified_on'   =>  $this->survey->timemodified,
-            'results'       =>  []
+            'modified_on'   =>  $this->survey->timemodified
         ];
     }
 

--- a/local/scripts/classes/serializers/SurveySerializer.php
+++ b/local/scripts/classes/serializers/SurveySerializer.php
@@ -1,5 +1,18 @@
 <?php
-use BirknerAlex\XMPPHP\Exception;
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'moodlelib.php');
 require_once(dirname(dirname(dirname(dirname(dirname(__FILE__))))) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'accesslib.php');
 

--- a/local/scripts/classes/serializers/SurveySerializer.php
+++ b/local/scripts/classes/serializers/SurveySerializer.php
@@ -74,6 +74,10 @@ class SurveySerializer
      */
     public function results($courseId, $courseModuleId)
     {
+        if (!$this->survey) {
+            return [];
+        }
+
         $results = [];
         // Get and collate all answers in a single array
         $answers = $this->db->get_records('survey_answers', ['survey'   =>  $this->survey->id], 'time ASC');

--- a/local/scripts/classes/serializers/SurveySerializer.php
+++ b/local/scripts/classes/serializers/SurveySerializer.php
@@ -67,6 +67,10 @@ class SurveySerializer
     /**
      * Get the results from the survey.  Adapted from code in mod/survey/download.php.
      * 
+     * @param integer $courseId         The id of the course
+     * @param integer $courseModuleId   The id for the course module
+     * 
+     * @return array                    The results
      */
     public function results($courseId, $courseModuleId)
     {

--- a/local/scripts/sync-course-testing-reports.php
+++ b/local/scripts/sync-course-testing-reports.php
@@ -19,15 +19,8 @@
  * If you want to use on command line, use `php sync.php true 'PASSWORD'`. Use single quotes on the password to allow special characters.
  */
 $cliScript = false;
-$password = '';
 if ((isset($argv)) && (isset($argv[1]))) {
     $cliScript = boolval($argv[1]);
-}
-if ((isset($argv)) && (isset($argv[2]))) {
-    $password = $argv[2];
-} else {
-    echo "You must provide a valid password!\r\n";
-    exit;
 }
 
 define('CLI_SCRIPT', $cliScript);
@@ -36,29 +29,79 @@ set_time_limit(0);
 
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
+require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'mod' . DIRECTORY_SEPARATOR . 'quiz' . DIRECTORY_SEPARATOR . 'locallib.php');
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'utilities.php');
 
-scripts_curl_download_file(
-    $CFG->wwwroot,
-    'admin',
-    $password,
-    $CFG->wwwroot . '/mod/quiz/report.php?download=csv&id=543&mode=responses&attempts=enrolled_with&onlygraded=&qtext=1&resp=1&right=1',
-    dirname(__FILE__) . DIRECTORY_SEPARATOR . 'response-543.csv'
-);
-// $courses = get_courses();
-// $approvedActivities = ['choice', 'quiz', 'feedback', 'survey'];
+$quizQuery = "SELECT DISTINCT '' || u.id || '#' || COALESCE(quiza.attempt, 0) AS uniqueid, " . 
+"(CASE WHEN (quiza.state = 'finished' AND NOT EXISTS ( SELECT 1 FROM {quiz_attempts} qa2 " .
+"WHERE qa2.quiz = quiza.quiz AND qa2.userid = quiza.userid AND qa2.state = 'finished' AND " .
+"( COALESCE(qa2.sumgrades, 0) > COALESCE(quiza.sumgrades, 0) OR (COALESCE(qa2.sumgrades, 0) = COALESCE(quiza.sumgrades, 0) " .
+"AND qa2.attempt < quiza.attempt) ))) THEN 1 ELSE 0 END) AS gradedattempt, quiza.uniqueid AS usageid, quiza.id AS attempt, " .
+"u.id AS userid, u.idnumber, u.firstnamephonetic,u.lastnamephonetic,u.middlename,u.alternatename,u.firstname,u.lastname, " .
+"u.institution, u.department, u.email, quiza.state, quiza.sumgrades, quiza.timefinish, quiza.timestart, CASE WHEN quiza.timefinish = 0 " .
+"THEN null WHEN quiza.timefinish > quiza.timestart THEN quiza.timefinish - quiza.timestart ELSE 0 END AS duration, " .
+"COALESCE(( SELECT MAX(qqr.regraded) FROM {quiz_overview_regrades} qqr WHERE qqr.questionusageid = quiza.uniqueid ), -1) " .
+"AS regraded FROM {user} u LEFT JOIN {quiz_attempts} quiza ON quiza.userid = u.id AND quiza.quiz = :quizid JOIN {user_enrolments} " .
+"ej1_ue ON ej1_ue.userid = u.id JOIN {enrol} ej1_e ON (ej1_e.id = ej1_ue.enrolid AND ej1_e.courseid = :courseid) JOIN " .
+"(SELECT DISTINCT userid FROM {role_assignments} WHERE contextid IN (1,565,717,738) AND roleid IN (5) ) ra ON ra.userid = u.id " .
+"WHERE quiza.preview = 0 AND quiza.id IS NOT NULL AND u.deleted = 0 AND u.id <> 1 AND u.deleted = 0";
 
-// foreach ($courses as $course) {
-//     if (intval($course->id) === 1) {
-//         continue;
-//     }
-//     $activities = get_array_of_activities($course->id);
-//     foreach ($activities as $activity) {
-//         if (!in_array($activity->mod, $approvedActivities)) {
-//             continue;
-//         }
-//         if ($activity->mod === 'quiz') {
+$courses = get_courses();
+$approvedActivities = ['choice', 'quiz', 'feedback', 'survey'];
 
-//         }
-//     }
-// }
+$tests = [];
+foreach ($courses as $course) {
+    if (intval($course->id) === 1) {
+        continue;
+    }
+    $courseDetails = [
+        'id'            =>  $course->id,
+        'fullname'      =>  $course->fullname,
+        'shortname'     =>  $course->shortname,
+        'summary'       =>  strip_tags($course->summary),
+        'created_on'    =>  $course->timecreated,
+        'modified_on'   =>  $course->timemodified
+    ];
+    $activities = get_array_of_activities($course->id);
+    foreach ($activities as $activity) {
+        if (!in_array($activity->mod, $approvedActivities)) {
+            continue;
+        }
+        $activityDetails = null;
+        if ($activity->mod === 'quiz') {
+            $quiz = $DB->get_record('quiz', array('id' => $activity->id));
+            if (!$quiz) {
+                continue;
+            }
+            $activityDetails = [
+                'id'            =>  $quiz->id,
+                'type'          =>  'quiz',
+                'name'          =>  $quiz->name,
+                'intro'         =>  strip_tags($quiz->intro),
+                'max_grade'     =>  $quiz->grade,
+                'created_on'    =>  $quiz->timecreated,
+                'modified_on'   =>  $quiz->timemodified,
+                'results'       =>  []
+            ];
+            $results = $DB->get_records_sql($quizQuery, ['quizid'  =>  $quiz->id, 'courseid' => $course->id]);
+            foreach ($results as $result) {
+                $activityDetails['results'][] = [
+                    'firstname'     =>  $result->firstname,
+                    'lastname'      =>  $result->lastname,
+                    'duration'      =>  $result->duration,
+                    'grade'         =>  quiz_rescale_grade($result->sumgrades, $quiz),
+                    'state'         =>  quiz_attempt_state_name($result->state),
+                    'started_on'    =>  $result->timestart,
+                    'finished_on'   =>  $result->timefinish,
+                ];
+            }
+        }
+        if ($activityDetails) {
+            $tests[] = [
+                'course'    =>  $courseDetails,
+                'activity'  =>  $activityDetails
+            ];
+        }
+    }
+}
+print_r($tests);

--- a/local/scripts/sync-course-testing-reports.php
+++ b/local/scripts/sync-course-testing-reports.php
@@ -36,66 +36,9 @@ set_time_limit(0);
 
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'utilities.php');
 
-/**
- * Login the account and download the given file
- * 
- * @param string $siteUrl   The URL for the website
- * @param string $username  The username to log into
- * @param string $password  The password of the given user
- * @param string $remoteFile    The remote file to download
- * @param string $localFile The local file where to store the contents
- * 
- * @return void
- */
-function cts_get_file($siteUrl, $username, $password, $remoteFile, $localFile) {
-    $cookieFile = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'cookies.txt';
-    $tokenPattern = '/<input(?:.*?)name=\"logintoken\"(?:.*)value=\"([^"]+).*>/i';
-    /**
-     * Setup cURL. Since we need to get the logintoken, then login the user, and then get the file,
-     * we need to use the same initialized cURL instance.  It will fail otherwise.
-     */
-    $curl = curl_init();
-    curl_setopt($curl, CURLOPT_COOKIEJAR, $cookieFile);
-    curl_setopt($curl, CURLOPT_COOKIEFILE, $cookieFile);
-    curl_setopt($curl, CURLOPT_COOKIESESSION, true);
-    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 60);
-    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-    curl_setopt($curl, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
-    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
-    curl_setopt($curl, CURLOPT_AUTOREFERER, true);
-    curl_setopt($curl, CURLOPT_TIMEOUT, 60);
-    /**
-     *  First retrieve the logintoken
-     */
-    curl_setopt($curl, CURLOPT_URL, $siteUrl . '/login/index.php');
-    curl_setopt($curl, CURLOPT_POST, false);
-    $content = curl_exec($curl);
-    preg_match($tokenPattern, $content, $matches);
-    if (count($matches) <= 1) {
-        echo "Unable to get the login token. \r\n";
-        exit;
-    }
-    $payload = [
-        'username'      =>  $username,
-        'password'      =>  $password,
-        'logintoken'    =>  $matches[1]
-    ];
-    curl_setopt($curl, CURLOPT_URL, $siteUrl . '/login/index.php');
-    curl_setopt($curl, CURLOPT_POST, true);
-    //@link https://stackoverflow.com/a/15023426
-    curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($payload, '', '&'));
-    curl_exec($curl);
-
-    // get the file
-    curl_setopt($curl, CURLOPT_URL, $remoteFile);
-    curl_setopt($curl, CURLOPT_POST, false);
-    $contents = curl_exec($curl);
-    file_put_contents($localFile, $contents);
-    curl_close($curl);
-}
-cts_get_file(
+scripts_curl_download_file(
     $CFG->wwwroot,
     'admin',
     $password,

--- a/local/scripts/sync-course-testing-reports.php
+++ b/local/scripts/sync-course-testing-reports.php
@@ -30,6 +30,7 @@ set_time_limit(0);
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'QuizSerializer.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'SurveySerializer.php');
 
 $courses = get_courses();
 $approvedActivities = ['choice', 'quiz', 'feedback', 'survey'];
@@ -52,6 +53,7 @@ foreach ($courses as $course) {
         if (!in_array($activity->mod, $approvedActivities)) {
             continue;
         }
+        $serializer = null;
         $activityDetails = [];
         if ($activity->mod === 'quiz') {
             $serializer = new QuizSerializer($activity->id, $DB);
@@ -61,21 +63,11 @@ foreach ($courses as $course) {
             }
         }
         if ($activity->mod === 'survey') {
-            $survey = $DB->get_record('survey', ['id'   =>  $activity->id]);
-            if (!$survey) {
-                continue;
+            $serializer = new SurveySerializer($activity->id, $DB);
+            $activityDetails = $serializer->details();
+            if (!empty($activityDetails)) {
+                $activityDetails['results'] = $serializer->results($course->id, $activity->cm);
             }
-            // $activityDetails = [
-            //     'id'            =>  $survey->id,
-            //     'type'          =>  'survey',
-            //     'name'          =>  $survey->name,
-            //     'intro'         =>  strip_tags($survey->intro),
-            //     'created_on'    =>  $survey->timecreated,
-            //     'modified_on'   =>  $survey->timemodified,
-            //     'results'       =>  []
-            // ];
-            // $order = explode(',', $survey->questions);
-            // $questions = $DB->get_records_list('survey_questions', 'id', $order);
         }
         if (!empty($activityDetails)) {
             $tests[] = [

--- a/local/scripts/sync-course-testing-reports.php
+++ b/local/scripts/sync-course-testing-reports.php
@@ -96,6 +96,24 @@ foreach ($courses as $course) {
                 ];
             }
         }
+        if ($activity->mod === 'survey') {
+            $survey = $DB->get_record('survey', ['id'   =>  $activity->id]);
+            if (!$survey) {
+                continue;
+            }
+            $activityDetails = [
+                'id'            =>  $survey->id,
+                'type'          =>  'survey',
+                'name'          =>  $survey->name,
+                'intro'         =>  strip_tags($survey->intro),
+                'created_on'    =>  $survey->timecreated,
+                'modified_on'   =>  $survey->timemodified,
+                'results'       =>  []
+            ];
+            $order = explode(',', $survey->questions);
+            $questions = $DB->get_records_list('survey_questions', 'id', $order);
+            print_r($questions);
+        }
         if ($activityDetails) {
             $tests[] = [
                 'course'    =>  $courseDetails,
@@ -104,4 +122,4 @@ foreach ($courses as $course) {
         }
     }
 }
-print_r($tests);
+// print_r($tests);

--- a/local/scripts/sync-course-testing-reports.php
+++ b/local/scripts/sync-course-testing-reports.php
@@ -1,0 +1,121 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * Sync the current course tests and quiz reports with the cloud.
+ *
+ * If you want to use on command line, use `php sync.php true 'PASSWORD'`. Use single quotes on the password to allow special characters.
+ */
+$cliScript = false;
+$password = '';
+if ((isset($argv)) && (isset($argv[1]))) {
+    $cliScript = boolval($argv[1]);
+}
+if ((isset($argv)) && (isset($argv[2]))) {
+    $password = $argv[2];
+} else {
+    echo "You must provide a valid password!\r\n";
+    exit;
+}
+
+define('CLI_SCRIPT', $cliScript);
+
+set_time_limit(0);
+
+require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
+require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
+
+/**
+ * Login the account and download the given file
+ * 
+ * @param string $siteUrl   The URL for the website
+ * @param string $username  The username to log into
+ * @param string $password  The password of the given user
+ * @param string $remoteFile    The remote file to download
+ * @param string $localFile The local file where to store the contents
+ * 
+ * @return void
+ */
+function cts_get_file($siteUrl, $username, $password, $remoteFile, $localFile) {
+    $cookieFile = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'cookies.txt';
+    $tokenPattern = '/<input(?:.*?)name=\"logintoken\"(?:.*)value=\"([^"]+).*>/i';
+    /**
+     * Setup cURL. Since we need to get the logintoken, then login the user, and then get the file,
+     * we need to use the same initialized cURL instance.  It will fail otherwise.
+     */
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_COOKIEJAR, $cookieFile);
+    curl_setopt($curl, CURLOPT_COOKIEFILE, $cookieFile);
+    curl_setopt($curl, CURLOPT_COOKIESESSION, true);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 60);
+    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+    curl_setopt($curl, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
+    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($curl, CURLOPT_AUTOREFERER, true);
+    curl_setopt($curl, CURLOPT_TIMEOUT, 60);
+    /**
+     *  First retrieve the logintoken
+     */
+    curl_setopt($curl, CURLOPT_URL, $siteUrl . '/login/index.php');
+    curl_setopt($curl, CURLOPT_POST, false);
+    $content = curl_exec($curl);
+    preg_match($tokenPattern, $content, $matches);
+    if (count($matches) <= 1) {
+        echo "Unable to get the login token. \r\n";
+        exit;
+    }
+    $payload = [
+        'username'      =>  $username,
+        'password'      =>  $password,
+        'logintoken'    =>  $matches[1]
+    ];
+    curl_setopt($curl, CURLOPT_URL, $siteUrl . '/login/index.php');
+    curl_setopt($curl, CURLOPT_POST, true);
+    //@link https://stackoverflow.com/a/15023426
+    curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($payload, '', '&'));
+    curl_exec($curl);
+
+    // get the file
+    curl_setopt($curl, CURLOPT_URL, $remoteFile);
+    curl_setopt($curl, CURLOPT_POST, false);
+    $contents = curl_exec($curl);
+    file_put_contents($localFile, $contents);
+    curl_close($curl);
+}
+cts_get_file(
+    $CFG->wwwroot,
+    'admin',
+    $password,
+    $CFG->wwwroot . '/mod/quiz/report.php?download=csv&id=543&mode=responses&attempts=enrolled_with&onlygraded=&qtext=1&resp=1&right=1',
+    dirname(__FILE__) . DIRECTORY_SEPARATOR . 'response-543.csv'
+);
+// $courses = get_courses();
+// $approvedActivities = ['choice', 'quiz', 'feedback', 'survey'];
+
+// foreach ($courses as $course) {
+//     if (intval($course->id) === 1) {
+//         continue;
+//     }
+//     $activities = get_array_of_activities($course->id);
+//     foreach ($activities as $activity) {
+//         if (!in_array($activity->mod, $approvedActivities)) {
+//             continue;
+//         }
+//         if ($activity->mod === 'quiz') {
+
+//         }
+//     }
+// }

--- a/local/scripts/sync_course_logs.php
+++ b/local/scripts/sync_course_logs.php
@@ -1,0 +1,156 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+/**
+ * Sync the course logs with the local API.
+ *
+ * If you want to use on command line, use `php sync_course_logs.php API_URL API_TOKEN`.
+ */
+define('CLI_SCRIPT', true);
+
+$url = '';
+$token = '';
+if ((isset($argv)) && (isset($argv[1]))) {
+    $url = $argv[1];
+}
+if ((isset($argv)) && (isset($argv[2]))) {
+    $token = $argv[2];
+}
+if (empty($url)) {
+    echo "\r\nYou must provide a valid API url to post the information to.\r\n";
+    exit;
+}
+
+set_time_limit(0);
+
+require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
+require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'datalib.php');
+require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'CurlUtility.php');
+
+$courses = get_courses();
+/**
+ * This file stores the timestamp when we last pulled the log
+ */
+$pulledLogFile = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'logs_last_pulled.txt';
+/**
+ * @link https://docs.moodle.org/dev/Migrating_log_access_in_reports
+ */
+$manager = get_log_manager();
+$selectedReaders = $manager->get_readers('\core\log\sql_reader');
+if ($selectedReaders) {
+    $reader = reset($selectedReaders);
+} else {
+    echo "\r\nNo log readers are available.\r\n";
+    exit;
+}
+$pulledLast = null;
+if (file_exists($pulledLogFile)) {
+    $pulledLast = file_get_contents($pulledLogFile);
+}
+$data = [];
+foreach ($courses as $course) {
+    if (intval($course->id) === 1) {
+        // The first course is The Well
+        continue;
+    }
+    $courseDetails = [
+        'id'            =>  $course->id,
+        'fullname'      =>  $course->fullname,
+        'shortname'     =>  $course->shortname,
+        'summary'       =>  strip_tags($course->summary),
+        'created_on'    =>  $course->timecreated,
+        'modified_on'   =>  $course->timemodified
+    ];
+    $where = 'courseid = ?';
+    $params = [$course->id];
+    if ($pulledLast) {
+        $where .= ' AND timecreated > ?';
+        $params[] = $pulledLast;
+    }
+    $iterator = $reader->get_events_select_iterator($where, $params, 'timecreated DESC', 0, 0);
+    $logs = [];
+    foreach ($iterator as $item) {
+        $extra = $item->get_logextra();
+        $origin = ($extra && array_key_exists('origin', $extra)) ? $extra['origin'] : '';
+        $ip = ($extra && array_key_exists('ip', $extra)) ? $extra['ip'] : '';
+        $log = [
+            'action'        =>  $item->action,
+            'component'     =>  $item->component,
+            'created_on'    =>  $item->timecreated,
+            'crud'          =>  $item->crud,
+            'description'   =>  $item->get_description(),
+            'event_name'    =>  $item->eventname,
+            'name'          =>  $item->get_name(),
+            'origin'        =>  $origin,
+            'ip_address'    =>  $ip,
+            'involved'      =>  []
+        ];
+        if ($item->userid) {
+            $user = $DB->get_record('user', ['id' => $item->userid]);
+            if ($user) {
+                $log['involved'][] = [
+                    'id'            =>  $user->id,
+                    'type'          =>  'user',
+                    'firstname'     =>  $user->firstname,
+                    'lastname'      =>  $user->lastname
+                ];
+            }
+        }
+        if (($item->relateduserid) && ($item->relateduserid !== $item->userid)) {
+            $user = $DB->get_record('user', ['id' => $item->relateduserid]);
+            if ($user) {
+                $log['involved'][] = [
+                    'id'            =>  $user->id,
+                    'type'          =>  'user',
+                    'firstname'     =>  $user->firstname,
+                    'lastname'      =>  $user->lastname
+                ];
+            }
+        }
+        if ($item->objectid) {
+            $object = $DB->get_record($item->objecttable, ['id' => $item->objectid]);
+            if ($object) {
+                $name = '';
+                if (property_exists($object, 'description') && $object->description !== '') {
+                    $name = $object->description;
+                }
+                if (property_exists($object, 'shortname') && $object->shortname !== '') {
+                    $name = $object->shortname;
+                }
+                if (property_exists($object, 'name') && $object->name !== '') {
+                    $name = $object->name;
+                }
+                $log['involved'][] = [
+                    'id'            =>  $object->id,
+                    'type'          =>  $item->objecttable,
+                    'name'          =>  $name
+                ];
+            }
+        }
+        $logs[] = $log;
+    }
+    if (!empty($logs)) {
+        $data[] = [
+            'course'    =>  $courseDetails,
+            'logs'      =>  $logs
+        ];
+    }
+}
+if (!empty($data)) {
+    echo "\r\LOGS:\r\n";
+    print_r(json_encode($data, JSON_NUMERIC_CHECK));
+}
+file_put_contents($pulledLogFile, time());

--- a/local/scripts/sync_course_logs.php
+++ b/local/scripts/sync_course_logs.php
@@ -80,12 +80,12 @@ foreach ($courses as $course) {
         $where .= ' AND timecreated > ?';
         $params[] = $pulledLast;
     }
-    $iterator = $reader->get_events_select_iterator($where, $params, 'timecreated DESC', 0, 0);
+    $iterator = $reader->get_events_select_iterator($where, $params, 'timecreated ASC', 0, 0);
     $logs = [];
     foreach ($iterator as $item) {
         $extra = $item->get_logextra();
-        $origin = ($extra && array_key_exists('origin', $extra)) ? $extra['origin'] : '';
-        $ip = ($extra && array_key_exists('ip', $extra)) ? $extra['ip'] : '';
+        $origin = ($extra && array_key_exists('origin', $extra) && $extra['origin']) ? $extra['origin'] : '';
+        $ip = ($extra && array_key_exists('ip', $extra) && $extra['ip']) ? $extra['ip'] : '';
         $log = [
             'action'        =>  $item->action,
             'component'     =>  $item->component,
@@ -150,7 +150,12 @@ foreach ($courses as $course) {
     }
 }
 if (!empty($data)) {
-    echo "\r\LOGS:\r\n";
-    print_r(json_encode($data, JSON_NUMERIC_CHECK));
+    $lastSync = ($pulledLast) ? intval($pulledLast) : -1;
+    $payload = [
+        'data'      =>  $data,
+        'last_sync' =>  $lastSync
+    ];
+    echo "\r\nLOGS:\r\n";
+    print_r(json_encode($payload, JSON_NUMERIC_CHECK));
 }
 file_put_contents($pulledLogFile, time());

--- a/local/scripts/sync_course_logs.php
+++ b/local/scripts/sync_course_logs.php
@@ -149,6 +149,10 @@ foreach ($courses as $course) {
         ];
     }
 }
+/**
+ * Send everything to the API
+ */
+$curl = new CurlUtility($url, $token);
 if (!empty($data)) {
     $lastSync = ($pulledLast) ? intval($pulledLast) : -1;
     $payload = [
@@ -157,5 +161,12 @@ if (!empty($data)) {
     ];
     echo "\r\nLOGS:\r\n";
     print_r(json_encode($payload, JSON_NUMERIC_CHECK));
+
+    $curl->makeRequest('/lms/stats/logs', 'POST', json_encode($payload), null, true);
+    if ($curl->responseCode === 200) {
+        echo "\r\nLogs have been successfully sent to the API.\r\n";
+        file_put_contents($pulledLogFile, time());
+    } else {
+        echo "\r\nError! Logs were not sent to the API.\r\n";
+    }
 }
-file_put_contents($pulledLogFile, time());

--- a/local/scripts/sync_course_testing_reports.php
+++ b/local/scripts/sync_course_testing_reports.php
@@ -18,12 +18,7 @@
  *
  * If you want to use on command line, use `php sync.php true 'PASSWORD'`. Use single quotes on the password to allow special characters.
  */
-$cliScript = false;
-if ((isset($argv)) && (isset($argv[1]))) {
-    $cliScript = boolval($argv[1]);
-}
-
-define('CLI_SCRIPT', $cliScript);
+define('CLI_SCRIPT', true);
 
 set_time_limit(0);
 

--- a/local/scripts/sync_course_testing_reports.php
+++ b/local/scripts/sync_course_testing_reports.php
@@ -31,7 +31,9 @@ require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEP
 $courses = get_courses();
 $approvedActivities = ['assign', 'quiz', 'survey'];
 
-$tests = [];
+$assignments = [];
+$quizes = [];
+$surveys = [];
 foreach ($courses as $course) {
     if (intval($course->id) === 1) {
         continue;
@@ -50,22 +52,19 @@ foreach ($courses as $course) {
             continue;
         }
         $serializer = null;
-        $activityDetails = [];
         if ($activity->mod === 'quiz') {
             $serializer = new QuizSerializer($activity->id, $DB);
             $activityDetails = $serializer->details();
             if (!empty($activityDetails)) {
                 $activityDetails['results'] = $serializer->results($course->id);
             }
-        }
-        if ($activity->mod === 'survey') {
+        } else if ($activity->mod === 'survey') {
             $serializer = new SurveySerializer($activity->id, $DB);
             $activityDetails = $serializer->details();
             if (!empty($activityDetails)) {
                 $activityDetails['results'] = $serializer->results($course->id, $activity->cm);
             }
-        }
-        if ($activity->mod === 'assign') {
+        } else if ($activity->mod === 'assign') {
             $serializer = new AssignmentSerializer($activity->id, $DB);
             $activityDetails = $serializer->details();
             if (!empty($activityDetails)) {
@@ -73,11 +72,23 @@ foreach ($courses as $course) {
             }
         }
         if (!empty($activityDetails)) {
-            $tests[] = [
+            $data = [
                 'course'    =>  $courseDetails,
                 'activity'  =>  $activityDetails
             ];
+            if ($activity->mod === 'quiz') {
+                $quizes[] = $data;
+            } else if ($activity->mod === 'survey') {
+                $surveys[] = $data;
+            } else if ($activity->mod === 'assign') {
+                $assignments[] = $data;
+            }
         }
     }
 }
-//print_r($tests);
+echo "ASSIGNMENTS:\r\n";
+print_r(json_encode($assignments, JSON_NUMERIC_CHECK));
+echo "\r\nQUIZES:\r\n";
+print_r(json_encode($quizes, JSON_NUMERIC_CHECK));
+echo "\r\nSURVEYS:\r\n";
+print_r(json_encode($surveys, JSON_NUMERIC_CHECK));

--- a/local/scripts/sync_course_testing_reports.php
+++ b/local/scripts/sync_course_testing_reports.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 /**
- * Sync the current course tests and quiz reports with the cloud.
+ * Sync the current course tests and quiz reports with the local API.
  *
  * If you want to use on command line, use `php sync_course_testing_reports.php API_URL API_TOKEN`.
  */

--- a/local/scripts/sync_course_testing_reports.php
+++ b/local/scripts/sync_course_testing_reports.php
@@ -25,13 +25,15 @@ set_time_limit(0);
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'AssignmentSerializer.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'FeedbackSerializer.php');
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'QuizSerializer.php');
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'SurveySerializer.php');
 
 $courses = get_courses();
-$approvedActivities = ['assign', 'quiz', 'survey'];
+$approvedActivities = ['assign', 'feedback', 'quiz', 'survey'];
 
 $assignments = [];
+$feedback = [];
 $quizes = [];
 $surveys = [];
 foreach ($courses as $course) {
@@ -70,6 +72,12 @@ foreach ($courses as $course) {
             if (!empty($activityDetails)) {
                 $activityDetails['results'] = $serializer->results($course->id, $activity->cm);
             }
+        } else if ($activity->mod === 'feedback') {
+            $serializer = new FeedbackSerializer($activity->id, $DB);
+            $activityDetails = $serializer->details();
+            if (!empty($activityDetails)) {
+                $activityDetails['results'] = $serializer->results();
+            }
         }
         if (!empty($activityDetails)) {
             $data = [
@@ -82,12 +90,16 @@ foreach ($courses as $course) {
                 $surveys[] = $data;
             } else if ($activity->mod === 'assign') {
                 $assignments[] = $data;
+            } else if ($activity->mod === 'feedback') {
+                $feedback[] = $data;
             }
         }
     }
 }
 echo "ASSIGNMENTS:\r\n";
 print_r(json_encode($assignments, JSON_NUMERIC_CHECK));
+echo "\r\nFEEDBACK:\r\n";
+print_r(json_encode($feedback, JSON_NUMERIC_CHECK));
 echo "\r\nQUIZES:\r\n";
 print_r(json_encode($quizes, JSON_NUMERIC_CHECK));
 echo "\r\nSURVEYS:\r\n";

--- a/local/scripts/sync_course_testing_reports.php
+++ b/local/scripts/sync_course_testing_reports.php
@@ -16,7 +16,7 @@
 /**
  * Sync the current course tests and quiz reports with the cloud.
  *
- * If you want to use on command line, use `php sync.php true 'PASSWORD'`. Use single quotes on the password to allow special characters.
+ * If you want to use on command line, use `php sync_course_testing_reports.php`.
  */
 define('CLI_SCRIPT', true);
 

--- a/local/scripts/sync_course_testing_reports.php
+++ b/local/scripts/sync_course_testing_reports.php
@@ -110,39 +110,51 @@ foreach ($courses as $course) {
         }
     }
 }
-echo "ASSIGNMENTS:\r\n";
-print_r(json_encode($assignments, JSON_NUMERIC_CHECK));
-echo "\r\nFEEDBACK:\r\n";
-print_r(json_encode($feedback, JSON_NUMERIC_CHECK));
-echo "\r\nquizzes:\r\n";
-print_r(json_encode($quizzes, JSON_NUMERIC_CHECK));
-echo "\r\nSURVEYS:\r\n";
-print_r(json_encode($surveys, JSON_NUMERIC_CHECK));
 /**
  * Send everything to the API
  */
 $curl = new CurlUtility($url, $token);
-$curl->makeRequest('/lms/stats/assignments', 'POST', json_encode($assignments), null, true);
-if ($curl->responseCode === 200) {
-    echo "\r\nAssignments have been successfully sent to the API.\r\n";
-} else {
-    echo "\r\nError! Assignments were not sent to the API.\r\n";
+if (!empty($assignments)) {
+    echo "ASSIGNMENTS:\r\n";
+    print_r(json_encode($assignments, JSON_NUMERIC_CHECK));
+
+    $curl->makeRequest('/lms/stats/assignments', 'POST', json_encode($assignments), null, true);
+    if ($curl->responseCode === 200) {
+        echo "\r\nAssignments have been successfully sent to the API.\r\n";
+    } else {
+        echo "\r\nError! Assignments were not sent to the API.\r\n";
+    }
 }
-$curl->makeRequest('/lms/stats/feedback', 'POST', json_encode($feedback), null, true);
-if ($curl->responseCode === 200) {
-    echo "\r\nFeedback has been successfully sent to the API.\r\n";
-} else {
-    echo "\r\nError! Feedback were not sent to the API.\r\n";
+if (!empty($feedback)) {
+    echo "\r\nFEEDBACK:\r\n";
+    print_r(json_encode($feedback, JSON_NUMERIC_CHECK));
+
+    $curl->makeRequest('/lms/stats/feedback', 'POST', json_encode($feedback), null, true);
+    if ($curl->responseCode === 200) {
+        echo "\r\nFeedback has been successfully sent to the API.\r\n";
+    } else {
+        echo "\r\nError! Feedback were not sent to the API.\r\n";
+    }
 }
-$curl->makeRequest('/lms/stats/quizzes', 'POST', json_encode($quizzes), null, true);
-if ($curl->responseCode === 200) {
-    echo "\r\nQuizzes have been successfully sent to the API.\r\n";
-} else {
-    echo "\r\nError! Quizzes were not sent to the API.\r\n";
+if (!empty($quizzes)) {
+    echo "\r\nQUIZZES:\r\n";
+    print_r(json_encode($quizzes, JSON_NUMERIC_CHECK));
+
+    $curl->makeRequest('/lms/stats/quizzes', 'POST', json_encode($quizzes), null, true);
+    if ($curl->responseCode === 200) {
+        echo "\r\nQuizzes have been successfully sent to the API.\r\n";
+    } else {
+        echo "\r\nError! Quizzes were not sent to the API.\r\n";
+    }
 }
-$curl->makeRequest('/lms/stats/surveys', 'POST', json_encode($surveys), null, true);
-if ($curl->responseCode === 200) {
-    echo "\r\nSurveys have been successfully sent to the API.\r\n";
-} else {
-    echo "\r\nError! Surveys were not sent to the API.\r\n";
+if (!empty($surveys)) {
+    echo "\r\nSURVEYS:\r\n";
+    print_r(json_encode($surveys, JSON_NUMERIC_CHECK));
+
+    $curl->makeRequest('/lms/stats/surveys', 'POST', json_encode($surveys), null, true);
+    if ($curl->responseCode === 200) {
+        echo "\r\nSurveys have been successfully sent to the API.\r\n";
+    } else {
+        echo "\r\nError! Surveys were not sent to the API.\r\n";
+    }
 }

--- a/local/scripts/sync_course_testing_reports.php
+++ b/local/scripts/sync_course_testing_reports.php
@@ -24,11 +24,12 @@ set_time_limit(0);
 
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'config.php');
 require_once(dirname(dirname(dirname(__FILE__))) . DIRECTORY_SEPARATOR . 'course' . DIRECTORY_SEPARATOR . 'lib.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'AssignmentSerializer.php');
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'QuizSerializer.php');
 require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'serializers' . DIRECTORY_SEPARATOR . 'SurveySerializer.php');
 
 $courses = get_courses();
-$approvedActivities = ['choice', 'quiz', 'feedback', 'survey'];
+$approvedActivities = ['assign', 'quiz', 'survey'];
 
 $tests = [];
 foreach ($courses as $course) {
@@ -64,6 +65,13 @@ foreach ($courses as $course) {
                 $activityDetails['results'] = $serializer->results($course->id, $activity->cm);
             }
         }
+        if ($activity->mod === 'assign') {
+            $serializer = new AssignmentSerializer($activity->id, $DB);
+            $activityDetails = $serializer->details();
+            if (!empty($activityDetails)) {
+                $activityDetails['results'] = $serializer->results($course->id, $activity->cm);
+            }
+        }
         if (!empty($activityDetails)) {
             $tests[] = [
                 'course'    =>  $courseDetails,
@@ -72,4 +80,4 @@ foreach ($courses as $course) {
         }
     }
 }
-print_r($tests);
+//print_r($tests);

--- a/local/scripts/utilities.php
+++ b/local/scripts/utilities.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Various utility functions
+ */
+/**
+ * Login the account and download the given file
+ * 
+ * @param string $siteUrl   The URL for the website
+ * @param string $username  The username to log into
+ * @param string $password  The password of the given user
+ * @param string $remoteFile    The remote file to download
+ * @param string $localFile The local file where to store the contents
+ * 
+ * @return void
+ */
+function scripts_curl_download_file($siteUrl, $username, $password, $remoteFile, $localFile) {
+    $cookieFile = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'cookies.txt';
+    $tokenPattern = '/<input(?:.*?)name=\"logintoken\"(?:.*)value=\"([^"]+).*>/i';
+    /**
+     * Setup cURL. Since we need to get the logintoken, then login the user, and then get the file,
+     * we need to use the same initialized cURL instance.  It will fail otherwise.
+     */
+    $curl = curl_init();
+    curl_setopt($curl, CURLOPT_COOKIEJAR, $cookieFile);
+    curl_setopt($curl, CURLOPT_COOKIEFILE, $cookieFile);
+    curl_setopt($curl, CURLOPT_COOKIESESSION, true);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 60);
+    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+    curl_setopt($curl, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
+    curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($curl, CURLOPT_AUTOREFERER, true);
+    curl_setopt($curl, CURLOPT_TIMEOUT, 60);
+    /**
+     *  First retrieve the logintoken
+     */
+    curl_setopt($curl, CURLOPT_URL, $siteUrl . '/login/index.php');
+    curl_setopt($curl, CURLOPT_POST, false);
+    $content = curl_exec($curl);
+    preg_match($tokenPattern, $content, $matches);
+    if (count($matches) <= 1) {
+        echo "Unable to get the login token. \r\n";
+        exit;
+    }
+    $payload = [
+        'username'      =>  $username,
+        'password'      =>  $password,
+        'logintoken'    =>  $matches[1]
+    ];
+    curl_setopt($curl, CURLOPT_URL, $siteUrl . '/login/index.php');
+    curl_setopt($curl, CURLOPT_POST, true);
+    /**
+     * @link https://stackoverflow.com/a/15023426
+     */
+    curl_setopt($curl, CURLOPT_POSTFIELDS, http_build_query($payload, '', '&'));
+    curl_exec($curl);
+
+    // get the file
+    curl_setopt($curl, CURLOPT_URL, $remoteFile);
+    curl_setopt($curl, CURLOPT_POST, false);
+    $contents = curl_exec($curl);
+    file_put_contents($localFile, $contents);
+    curl_close($curl);
+}


### PR DESCRIPTION
Added two scripts to help facilitate syncing Moodle testing data with our future cloud service.  The scripts collect the data, and post it to future endpoints in [the Well PWA](https://github.com/RT-coding-team/TheWell-PWA).  Placeholder endpoints have been implemented on [this pull request](https://github.com/RT-coding-team/TheWell-PWA/pull/3).  The scripts do the following:

- **local/scripts/sync_course_logs.php** - Gets all course logs from the last sync time up to now. Then posts it to the new endpoints.
- **local/scripts/sync_course_testing_reports.php** - Gets all the assignments, quizzes, feedback, and surveys for the courses. Then posts the data to separate new endpoints on the PWA.

For the sync_course_testing_reports.php script, it always passes the complete data.  So when inserting in a database, we should clear the old data.