### PR TITLE
Course Restore Naming

### DIFF
--- a/admin/cli/restore_backup.php
+++ b/admin/cli/restore_backup.php
@@ -127,6 +127,12 @@ try {
 		$DB->execute($updatesql, $params);
 	}
 } catch (Exception $e) {
+    if (isset($courseid)) {
+        /**
+         * The course was saved, but then failed to be restored. Let's delete it.
+         */
+        delete_course($courseid);
+    }
     cli_heading(get_string('cleaningtempdata'));
     fulldelete($path);
     print_error('generalexceptionmessage', 'error', '', $e->getMessage());

--- a/admin/cli/restore_backup.php
+++ b/admin/cli/restore_backup.php
@@ -113,17 +113,17 @@ try {
 		}    
 
 		# Get existing course names and modify them: (1) take out the copy stuff, (2) add the suffix
-		$chats = $DB->get_record('course', array('id'=>$courseid), 'fullname,shortname', MUST_EXIST);
-		if (str_contains($chats->fullname,' copy ')) {
-			$chats->fullname = substr($chats->fullname, 0, strpos($chats->fullname, " copy "));
-			$chats->shortname = substr($chats->shortname, 0, strpos($chats->shortname, "_"));	
+		$course = $DB->get_record('course', array('id'=>$courseid), 'fullname,shortname', MUST_EXIST);
+		if (str_contains($course->fullname,' copy ')) {
+			$course->fullname = substr($course->fullname, 0, strpos($course->fullname, " copy "));
+			$course->shortname = substr($course->shortname, 0, strpos($course->shortname, "_"));	
 		}
-		$chats->fullname = $chats->fullname . ' ' . $options['suffix'];
-		$chats->shortname = $chats->shortname . ' ' . $options['suffix'];
+		$course->fullname = $course->fullname . ' ' . $options['suffix'];
+		$course->shortname = $course->shortname . ' ' . $options['suffix'];
 
 		# Update the database course names via SQL
 		$updatesql = "UPDATE mdl_course SET fullname = :fullname, shortname = :shortname WHERE id = :courseid";
-		$params = ['fullname' => $chats->fullname, 'shortname' => $chats->shortname,'courseid' => $courseid];
+		$params = ['fullname' => $course->fullname, 'shortname' => $course->shortname,'courseid' => $courseid];
 		$DB->execute($updatesql, $params);
 	}
 } catch (Exception $e) {

--- a/admin/cli/restore_backup.php
+++ b/admin/cli/restore_backup.php
@@ -94,8 +94,7 @@ cli_heading(get_string('preprocessingbackupfile'));
 try {
     list($fullname, $shortname) = restore_dbops::calculate_course_names(0, get_string('restoringcourse', 'backup'),
         get_string('restoringcourseshortname', 'backup'));
-
-    $courseid = restore_dbops::create_new_course($fullname . "-derek", $shortname . "derek", $category->id);
+    $courseid = restore_dbops::create_new_course($fullname, $shortname, $category->id);
 
     $rc = new restore_controller($backupdir, $courseid, backup::INTERACTIVE_NO,
         backup::MODE_GENERAL, $admin->id, backup::TARGET_NEW_COURSE);
@@ -104,7 +103,7 @@ try {
     $rc->destroy();
 
 	// Added by Derek Maxson 20210413 -- allows a suffix to be added to the course name
-	if (isset($options['suffix'])) {
+	if ((isset($options['suffix'])) && (!empty($options['suffix']))) {
 		echo "Adding Suffix: " . $options['suffix'] . "\n";
 		# Older versions of PHP don't have the function, so we will make one 
 		if (!function_exists('str_contains')) {

--- a/course/lib.php
+++ b/course/lib.php
@@ -514,7 +514,7 @@ function get_array_of_activities($courseid) {
                            }
                        }
                    }
-                   if (!$mod[$seq]->icon) {
+                   if ((!property_exists($mod[$seq], 'icon')) || (!$mod[$seq]->icon)) {
                        /**
                         * Catch activities that haven't set an icon yet, and check
                         * if they have a custom icon


### PR DESCRIPTION
Patched several bugs in course restore:

- Removed the name Derek from the name of the course while it is still restoring.
- The suffix if condition was firing even though it was not provided.
- We now delete the course if there was an exception thrown during the restore.
- Remove a warning that was displaying because icon was not set on the course activities.

